### PR TITLE
Expand GCFScape GUI toward feature parity

### DIFF
--- a/extract-gcf.py
+++ b/extract-gcf.py
@@ -1,18 +1,35 @@
 
-from pysteam.fs.cachefile import CacheFile
-from optparse import OptionParser
-
-parser = OptionParser()
-parser.add_option("-m", "--minimum", action="store_true", dest="minimum", help="Extract minimum footprint only?")
-parser.add_option("-o", "--output", dest="output", help="Output directory for extraction.")
-options, args = parser.parse_args()
-
-cacheHandle = open(args[0],"rb")
-cacheFile = CacheFile.parse(cacheHandle)
-
+import argparse
 import os.path
-if options.minimum:
-    cacheFile.extract_minimum_footprint(os.path.realpath(options.output))
-else:
-    cacheFile.extract(os.path.realpath(options.output))
-cacheHandle.close()
+
+from pysteam.fs.cachefile import CacheFile
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Extract files from a Steam cache")
+    parser.add_argument("cachefile", help="Path to the cache file to extract")
+    parser.add_argument(
+        "-m",
+        "--minimum",
+        action="store_true",
+        help="Extract minimum footprint only",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        required=True,
+        help="Output directory for extraction",
+    )
+    args = parser.parse_args()
+
+    with open(args.cachefile, "rb") as cache_handle:
+        cache_file = CacheFile.parse(cache_handle)
+        output_dir = os.path.realpath(args.output)
+        if args.minimum:
+            cache_file.extract_minimum_footprint(output_dir)
+        else:
+            cache_file.extract(output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/gcfscape_gui.py
+++ b/gcfscape_gui.py
@@ -1,0 +1,916 @@
+#!/usr/bin/env python3
+"""GCFScape inspired GUI for browsing and extracting Steam cache files.
+
+This module provides a reasonably feature complete clone of the classic
+GCFScape application written in Python using PyQt5.  The goal is to mirror
+the look and feel of the original tool while keeping the code portable and
+easy to understand.  It intentionally favours readability over raw
+performance and serves as a reference implementation of how the original
+GCFScape behaves.
+
+Highlights
+=========
+
+* Tree based navigation of cache contents with live filtering.
+* File preview pane that attempts to display text files and falls back to a
+  hexadecimal dump for binary data.
+* Context menus, toolbars and menu layout mirroring the original tool.
+* Extraction of individual files or entire folders with progress reporting.
+* Simple properties dialog for both files and folders.
+* Recent file list stored via :class:`~PyQt5.QtCore.QSettings` for a more
+  native desktop experience.
+* Placeholder implementations of advanced features such as defragmentation
+  and validation to keep parity with the original UI.  These placeholders
+  can be expanded with real logic if desired.
+
+The code is intentionally verbose and heavily commented to make the control
+flow clear.  This also helps align the implementation more closely with the
+user interface of GCFScape where many seemingly small behaviours are
+performed behind the scenes.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+from PyQt5.QtCore import (
+    QObject,
+    Qt,
+    QThread,
+    QSettings,
+    pyqtSignal,
+    QSize,
+)
+from PyQt5.QtGui import QIcon, QFont, QCloseEvent
+from PyQt5.QtWidgets import (
+    QAction,
+    QApplication,
+    QDialog,
+    QDialogButtonBox,
+    QFileDialog,
+    QFormLayout,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QMainWindow,
+    QMenu,
+    QMessageBox,
+    QProgressBar,
+    QProgressDialog,
+    QPushButton,
+    QSplitter,
+    QStackedWidget,
+    QStatusBar,
+    QCheckBox,
+    QTextEdit,
+    QToolBar,
+    QTreeWidget,
+    QTreeWidgetItem,
+    QInputDialog,
+    QStyle,
+    QVBoxLayout,
+    QWidget,
+)
+
+# The pysteam cache file parser is used to read GCF/NCF archives.  It
+# exposes a similar API to the original C++ version used by GCFScape.
+from pysteam.fs.cachefile import CacheFile, CacheFileManifestEntry
+from pysteam.bsp.preview import BSPViewWidget
+from pysteam.image import ImageViewWidget
+from pysteam.vtf.preview import VTFViewWidget
+from pysteam.mdl.preview import MDLViewWidget
+def is_encrypted(entry) -> bool:
+    """Return ``True`` if the manifest flags mark ``entry`` as encrypted."""
+
+    manifest = getattr(entry, "_manifest_entry", None)
+    if not manifest:
+        return False
+    return bool(manifest.directory_flags & CacheFileManifestEntry.FLAG_IS_ENCRYPTED)
+
+
+# ---------------------------------------------------------------------------
+# Utility widgets and helpers
+# ---------------------------------------------------------------------------
+
+
+class EntryItem(QTreeWidgetItem):
+    """Tree widget item representing a cache entry.
+
+    The item stores a reference to the underlying cache entry object in its
+    ``entry`` attribute.  Additional convenience properties are provided to
+    reduce boilerplate when accessing the entry's information.
+    """
+
+    def __init__(self, entry) -> None:  # type: ignore[override]
+        super().__init__()
+        self.entry = entry
+        self.refresh()
+
+    # ------------------------------------------------------------------
+    def refresh(self) -> None:
+        """Update the visual representation to match the current entry."""
+
+        name = self.entry.name
+        size = str(self.entry.size()) if self.entry.is_file() else ""
+        etype = "File" if self.entry.is_file() else "Folder"
+
+        self.setText(0, name)
+        self.setText(1, size)
+        self.setText(2, etype)
+        icon = QApplication.style().standardIcon(
+            QStyle.SP_FileIcon if self.entry.is_file() else QStyle.SP_DirIcon
+        )
+        self.setIcon(0, icon)
+
+    # ------------------------------------------------------------------
+    def path(self) -> str:
+        return self.entry.path()
+
+
+class ExtractionWorker(QThread):
+    """Background worker extracting a list of files.
+
+    The worker reports progress via the :pyattr:`progress` signal and emits
+    :pyattr:`finished` or :pyattr:`error` when done.  Extraction can be
+    cancelled by calling :py:meth:`cancel`.
+    """
+
+    progress = pyqtSignal(int, str)
+    finished = pyqtSignal()
+    error = pyqtSignal(str)
+
+    def __init__(
+        self,
+        files: Iterable,
+        dest: str,
+        key: bytes | None = None,
+        parent: QObject | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.files = list(files)
+        self.dest = dest
+        self.key = key
+        self._cancelled = False
+
+    # ------------------------------------------------------------------
+    def run(self) -> None:  # type: ignore[override]
+        total = len(self.files)
+        for idx, entry in enumerate(self.files, 1):
+            if self._cancelled:
+                break
+            try:
+                self.progress.emit(int(idx / total * 100), entry.path())
+                if is_encrypted(entry) and self.key is None:
+                    raise ValueError("File is encrypted but no key was provided")
+                entry.extract(self.dest, keep_folder_structure=True, key=self.key)
+            except Exception as exc:  # pragma: no cover - worker thread
+                self.error.emit(str(exc))
+                return
+        self.finished.emit()
+
+    # ------------------------------------------------------------------
+    def cancel(self) -> None:
+        self._cancelled = True
+
+
+class PropertiesDialog(QDialog):
+    """Dialog showing information about a file or folder entry."""
+
+    def __init__(self, entry, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Properties")
+        layout = QFormLayout(self)
+        layout.addRow("Path:", QLabel(entry.path()))
+        if entry.is_file():
+            layout.addRow("Size:", QLabel(str(entry.size())))
+        else:
+            layout.addRow("Items:", QLabel(str(len(entry.items))))
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok)
+        buttons.accepted.connect(self.accept)
+        layout.addWidget(buttons)
+
+
+class SearchDialog(QDialog):
+    """Dialog used for advanced name searching within the tree."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Find")
+        self.resize(300, 100)
+        layout = QVBoxLayout(self)
+        form = QFormLayout()
+        self.pattern = QLineEdit()
+        form.addRow("Name contains:", self.pattern)
+        layout.addLayout(form)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+
+class OptionsDialog(QDialog):
+    """Very small placeholder for application options.
+
+    Only a tiny subset of the original tool's preferences are implemented.
+    Currently a single checkbox allows toggling the preview pane visibility on
+    application start-up.  The value is persisted via :class:`QSettings`.
+    """
+
+    def __init__(self, settings: QSettings, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.settings = settings
+        self.setWindowTitle("Options")
+        self.resize(300, 120)
+
+        layout = QVBoxLayout(self)
+        self.preview_check = QCheckBox("Show preview at startup")
+        self.preview_check.setChecked(self.settings.value("preview", True, bool))
+        layout.addWidget(self.preview_check)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    # ------------------------------------------------------------------
+    @property
+    def preview_enabled(self) -> bool:
+        return self.preview_check.isChecked()
+
+    # ------------------------------------------------------------------
+    def accept(self) -> None:  # type: ignore[override]
+        self.settings.setValue("preview", self.preview_check.isChecked())
+        super().accept()
+
+
+class PreviewWidget(QWidget):
+    """Widget displaying a preview of the currently selected file."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        self.stack = QStackedWidget()
+        self.text_view = QTextEdit()
+        self.text_view.setReadOnly(True)
+        self.image_view = ImageViewWidget()
+        self.bsp_view = BSPViewWidget()
+        self.vtf_view = VTFViewWidget()
+        self.mdl_view = MDLViewWidget()
+        self.stack.addWidget(self.text_view)
+        self.stack.addWidget(self.image_view)
+        self.stack.addWidget(self.bsp_view)
+        self.stack.addWidget(self.vtf_view)
+        self.stack.addWidget(self.mdl_view)
+        layout.addWidget(self.stack)
+
+    # ------------------------------------------------------------------
+    def clear(self) -> None:
+        self.text_view.clear()
+        self.image_view.clear()
+        self.bsp_view.clear()
+        self.vtf_view.clear()
+        self.mdl_view.clear()
+        self.stack.setCurrentWidget(self.text_view)
+
+    # ------------------------------------------------------------------
+    def set_entry(self, entry) -> None:
+        """Display a preview for ``entry`` which may be a BSP or text file."""
+
+        name = entry.name.lower()
+        ext = os.path.splitext(name)[1]
+        key = None
+        if is_encrypted(entry):
+            key = self._request_key()
+            if key is None:
+                self.clear()
+                return
+
+        try:
+            stream = entry.open("rb", key=key)
+            data = stream.readall()
+        except Exception:
+            self.clear()
+            return
+        finally:
+            try:
+                stream.close()
+            except Exception:
+                pass
+
+        IMAGE_EXTS = {".gif", ".jpg", ".jpeg", ".bmp", ".png", ".tga", ".ico"}
+        TEXT_EXTS = {".res", ".txt", ".vmt", ".lst", ".xml", ".vdf", ".html"}
+
+        if ext == ".bsp":
+            self.bsp_view.load_map(data)
+            self.stack.setCurrentWidget(self.bsp_view)
+        elif ext == ".vtf":
+            self.vtf_view.load_vtf(data)
+            self.stack.setCurrentWidget(self.vtf_view)
+        elif ext == ".mdl":
+            self.mdl_view.load_model(data)
+            self.stack.setCurrentWidget(self.mdl_view)
+        elif ext in IMAGE_EXTS:
+            self.image_view.load_image(data)
+            self.stack.setCurrentWidget(self.image_view)
+        elif ext in TEXT_EXTS:
+            text = data.decode("utf-8", errors="replace")
+            self.text_view.setPlainText(text)
+            self.stack.setCurrentWidget(self.text_view)
+        else:
+            text = " ".join(f"{b:02x}" for b in data)
+            self.text_view.setPlainText(text)
+            self.stack.setCurrentWidget(self.text_view)
+
+    # ------------------------------------------------------------------
+    def _request_key(self) -> bytes | None:
+        text, ok = QInputDialog.getText(self, "Encrypted file", "Enter decryption key:")
+        if not ok or not text:
+            return None
+        try:
+            return bytes.fromhex(text)
+        except ValueError:
+            return text.encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Main application window
+# ---------------------------------------------------------------------------
+
+
+class GCFScapeWindow(QMainWindow):
+    """Main window implementing the GCFScape GUI."""
+
+    settings = QSettings("pysteam", "gcfscape")
+
+    def __init__(self) -> None:
+        super().__init__()
+
+        self.setWindowTitle("GCFScape (Python Edition)")
+        self.resize(1000, 700)
+
+        self.cachefile: CacheFile | None = None
+        self.current_path: Path | None = None
+        self.entry_to_tree_item: dict = {}
+
+        # ------------------------------------------------------------------
+        # Central layout
+        # ------------------------------------------------------------------
+        splitter = QSplitter(self)
+
+        left_widget = QWidget()
+        left_layout = QVBoxLayout(left_widget)
+        left_layout.setContentsMargins(0, 0, 0, 0)
+
+        self.search = QLineEdit()
+        self.search.setPlaceholderText("Search…")
+        self.search.textChanged.connect(self._filter_tree)
+        left_layout.addWidget(self.search)
+
+        self.tree = QTreeWidget()
+        self.tree.setHeaderHidden(True)
+        self.tree.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.tree.customContextMenuRequested.connect(self._open_context_menu)
+        self.tree.itemSelectionChanged.connect(self._update_file_list)
+        left_layout.addWidget(self.tree)
+
+        right_splitter = QSplitter(Qt.Vertical)
+        self.file_list = QTreeWidget()
+        self.file_list.setHeaderLabels(["Name", "Size", "Type"])
+        self.file_list.setRootIsDecorated(False)
+        self.file_list.setItemsExpandable(False)
+        self.file_list.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.file_list.customContextMenuRequested.connect(self._open_context_menu)
+        self.file_list.itemSelectionChanged.connect(self._update_preview)
+        self.file_list.itemDoubleClicked.connect(self._file_list_double_clicked)
+        self.file_list.setSortingEnabled(True)
+        header = self.file_list.header()
+        header.setSectionResizeMode(0, QHeaderView.Stretch)
+        header.setSectionResizeMode(1, QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(2, QHeaderView.ResizeToContents)
+        right_splitter.addWidget(self.file_list)
+
+        self.preview = PreviewWidget()
+        right_splitter.addWidget(self.preview)
+        right_splitter.setStretchFactor(0, 3)
+        right_splitter.setStretchFactor(1, 1)
+        show_preview = self.settings.value("preview", True, bool)
+        self.preview.setVisible(show_preview)
+
+        splitter.addWidget(left_widget)
+        splitter.addWidget(right_splitter)
+        splitter.setStretchFactor(0, 1)
+        splitter.setStretchFactor(1, 2)
+        self.setCentralWidget(splitter)
+
+        # ------------------------------------------------------------------
+        # Status bar
+        # ------------------------------------------------------------------
+        status = QStatusBar()
+        self.setStatusBar(status)
+        self.progress_bar = QProgressBar()
+        self.progress_bar.hide()
+        status.addPermanentWidget(self.progress_bar, 1)
+
+        # ------------------------------------------------------------------
+        # Actions
+        # ------------------------------------------------------------------
+
+        self.open_action = QAction("&Open…", self)
+        self.open_action.triggered.connect(self._open_file)
+        self.close_action = QAction("&Close", self)
+        self.close_action.triggered.connect(self._close_file)
+        self.exit_action = QAction("E&xit", self)
+        self.exit_action.triggered.connect(self.close)
+
+        self.extract_action = QAction("Extract…", self)
+        self.extract_action.triggered.connect(lambda: self._extract_entry(self._current_entry()))
+        self.extract_all_action = QAction("Extract &All…", self)
+        self.extract_all_action.triggered.connect(self._extract_all)
+
+        self.refresh_action = QAction("&Refresh", self)
+        self.refresh_action.triggered.connect(self._refresh)
+        self.expand_action = QAction("Expand All", self)
+        self.expand_action.triggered.connect(self.tree.expandAll)
+        self.collapse_action = QAction("Collapse All", self)
+        self.collapse_action.triggered.connect(self.tree.collapseAll)
+
+        self.properties_action = QAction("Properties", self)
+        self.properties_action.triggered.connect(lambda: self._show_properties(self._current_entry()))
+
+        self.preview_toggle_action = QAction("Show Preview", self, checkable=True, checked=show_preview)
+        self.preview_toggle_action.toggled.connect(lambda checked: (self.preview.setVisible(checked), self.settings.setValue("preview", checked)))
+
+        self.find_action = QAction("&Find…", self)
+        self.find_action.triggered.connect(self._open_search_dialog)
+
+        self.defrag_action = QAction("&Defragment…", self)
+        self.defrag_action.triggered.connect(self._defragment)
+
+        self.validate_action = QAction("&Validate", self)
+        self.validate_action.triggered.connect(self._validate)
+
+        self.convert_v1_action = QAction("Convert to &V1…", self)
+        self.convert_v1_action.triggered.connect(lambda: self._convert_gcf(1))
+
+        self.convert_latest_action = QAction("Convert to &Latest…", self)
+        self.convert_latest_action.triggered.connect(lambda: self._convert_gcf(6))
+
+        self.options_action = QAction("&Options…", self)
+        self.options_action.triggered.connect(self._open_options)
+
+        self.about_action = QAction("&About", self)
+        self.about_action.triggered.connect(self._about)
+        self.about_qt_action = QAction("About &Qt", self)
+        self.about_qt_action.triggered.connect(QApplication.instance().aboutQt)
+
+        # ------------------------------------------------------------------
+        # Menus
+        # ------------------------------------------------------------------
+        menubar = self.menuBar()
+
+        file_menu = menubar.addMenu("&File")
+        file_menu.addAction(self.open_action)
+        file_menu.addAction(self.close_action)
+
+        self.recent_menu = file_menu.addMenu("Open &Recent")
+        self._rebuild_recent_menu()
+
+        file_menu.addSeparator()
+        file_menu.addAction(self.extract_action)
+        file_menu.addAction(self.extract_all_action)
+        file_menu.addSeparator()
+        file_menu.addAction(self.exit_action)
+
+        edit_menu = menubar.addMenu("&Edit")
+        edit_menu.addAction(self.find_action)
+        edit_menu.addAction(self.refresh_action)
+
+        view_menu = menubar.addMenu("&View")
+        view_menu.addAction(self.expand_action)
+        view_menu.addAction(self.collapse_action)
+        view_menu.addAction(self.preview_toggle_action)
+
+        tools_menu = menubar.addMenu("&Tools")
+        tools_menu.addAction(self.defrag_action)
+        tools_menu.addAction(self.validate_action)
+        tools_menu.addAction(self.convert_v1_action)
+        tools_menu.addAction(self.convert_latest_action)
+        tools_menu.addSeparator()
+        tools_menu.addAction(self.options_action)
+
+        help_menu = menubar.addMenu("&Help")
+        help_menu.addAction(self.about_action)
+        help_menu.addAction(self.about_qt_action)
+
+        # ------------------------------------------------------------------
+        # Toolbar mirroring the File menu
+        # ------------------------------------------------------------------
+        toolbar = QToolBar("Main", self)
+        toolbar.setIconSize(QSize(16, 16))
+        self.addToolBar(toolbar)
+        toolbar.addAction(self.open_action)
+        toolbar.addAction(self.close_action)
+        toolbar.addSeparator()
+        toolbar.addAction(self.extract_action)
+        toolbar.addAction(self.extract_all_action)
+        toolbar.addSeparator()
+        toolbar.addAction(self.refresh_action)
+
+        # Drag and drop support for convenience
+        self.setAcceptDrops(True)
+
+    # ------------------------------------------------------------------
+    # Utility methods
+    # ------------------------------------------------------------------
+
+    def _current_entry(self):
+        """Return the entry associated with the current selection."""
+        item = self.file_list.currentItem()
+        if isinstance(item, EntryItem):
+            return item.entry
+        item = self.tree.currentItem()
+        if isinstance(item, EntryItem):
+            return item.entry
+        return None
+
+    # ------------------------------------------------------------------
+    def dragEnterEvent(self, event):  # type: ignore[override]
+        if event.mimeData().hasUrls():
+            event.acceptProposedAction()
+
+    # ------------------------------------------------------------------
+    def dropEvent(self, event):  # type: ignore[override]
+        for url in event.mimeData().urls():
+            path = url.toLocalFile()
+            if path:
+                self._load_file(Path(path))
+                break
+
+    # ------------------------------------------------------------------
+    # Menu building helpers
+    # ------------------------------------------------------------------
+
+    def _rebuild_recent_menu(self) -> None:
+        self.recent_menu.clear()
+        recent = self.settings.value("recent", [], list)
+        for path in recent:
+            action = QAction(path, self)
+            action.triggered.connect(lambda checked=False, p=path: self._load_file(Path(p)))
+            self.recent_menu.addAction(action)
+        if not recent:
+            self.recent_menu.setEnabled(False)
+        else:
+            self.recent_menu.setEnabled(True)
+
+    # ------------------------------------------------------------------
+    def _add_to_recent(self, path: Path) -> None:
+        recent = self.settings.value("recent", [], list)
+        path_str = str(path)
+        if path_str in recent:
+            recent.remove(path_str)
+        recent.insert(0, path_str)
+        self.settings.setValue("recent", recent[:10])
+        self._rebuild_recent_menu()
+
+    # ------------------------------------------------------------------
+    # File operations
+    # ------------------------------------------------------------------
+
+    def _open_file(self) -> None:
+        path, _ = QFileDialog.getOpenFileName(
+            self,
+            "Open Steam cache file",
+            "",
+            "Steam Cache Files (*.gcf *.ncf *.vpk);;All Files (*)",
+        )
+        if path:
+            self._load_file(Path(path))
+
+    # ------------------------------------------------------------------
+    def _load_file(self, path: Path) -> None:
+        try:
+            with open(path, "rb") as handle:
+                self.cachefile = CacheFile.parse(handle)
+        except Exception as exc:  # pragma: no cover - GUI feedback
+            traceback.print_exc()
+            QMessageBox.critical(self, "Error", str(exc))
+            return
+
+        self.current_path = path
+        self._add_to_recent(path)
+        self.statusBar().showMessage(str(path))
+        self._populate_tree()
+
+    # ------------------------------------------------------------------
+    def _close_file(self) -> None:
+        self.cachefile = None
+        self.current_path = None
+        self.tree.clear()
+        self.file_list.clear()
+        self.preview.clear()
+        self.statusBar().clearMessage()
+        self.entry_to_tree_item.clear()
+
+    # ------------------------------------------------------------------
+    def _refresh(self) -> None:
+        if self.cachefile:
+            self._populate_tree()
+
+    # ------------------------------------------------------------------
+    # Tree and search functionality
+    # ------------------------------------------------------------------
+
+    def _populate_tree(self) -> None:
+        self.tree.clear()
+        self.file_list.clear()
+        self.entry_to_tree_item.clear()
+        if not self.cachefile:
+            return
+
+        root_entry = self.cachefile.root
+        root_item = EntryItem(root_entry)
+        root_item.setText(0, "root")
+        self.tree.addTopLevelItem(root_item)
+        self.entry_to_tree_item[root_entry] = root_item
+
+        def add_dirs(folder, parent_item):
+            for name, entry in sorted(folder.items.items()):
+                if entry.is_folder():
+                    item = EntryItem(entry)
+                    parent_item.addChild(item)
+                    self.entry_to_tree_item[entry] = item
+                    add_dirs(entry, item)
+
+        add_dirs(root_entry, root_item)
+        self.tree.setCurrentItem(root_item)
+        self._update_file_list()
+        self.tree.collapseAll()
+        self._filter_tree(self.search.text())
+
+    def _current_directory(self):
+        item = self.tree.currentItem()
+        if isinstance(item, EntryItem):
+            return item.entry
+        return None
+
+    def _update_file_list(self) -> None:
+        self.file_list.clear()
+        folder = self._current_directory()
+        if not folder:
+            return
+        for name, entry in sorted(folder.items.items()):
+            self.file_list.addTopLevelItem(EntryItem(entry))
+        self.preview.clear()
+        self.statusBar().showMessage(f"{folder.path()} ({len(folder.items)} items)")
+
+    def _file_list_double_clicked(self, item: QTreeWidgetItem, column: int) -> None:
+        if isinstance(item, EntryItem) and item.entry.is_folder():
+            tree_item = self.entry_to_tree_item.get(item.entry)
+            if tree_item:
+                self.tree.setCurrentItem(tree_item)
+
+    # ------------------------------------------------------------------
+    def _filter_tree(self, text: str) -> None:
+        text = text.lower()
+
+        def filter_item(item: QTreeWidgetItem) -> bool:
+            match = text in item.text(0).lower() if text else True
+            child_match = any(filter_item(item.child(i)) for i in range(item.childCount()))
+            item.setHidden(not (match or child_match))
+            return match or child_match
+
+        root = self.tree.invisibleRootItem()
+        for i in range(root.childCount()):
+            filter_item(root.child(i))
+
+    # ------------------------------------------------------------------
+    def _open_search_dialog(self) -> None:
+        dialog = SearchDialog(self)
+        if dialog.exec() == QDialog.Accepted:
+            pattern = dialog.pattern.text().lower()
+            self.search.setText(pattern)
+
+    # ------------------------------------------------------------------
+    def _update_preview(self) -> None:
+        entry = self._current_entry()
+        if not entry or entry.is_folder():
+            self.preview.clear()
+            return
+
+        self.preview.set_entry(entry)
+        self.statusBar().showMessage(entry.path())
+
+    # ------------------------------------------------------------------
+    # Context menu and actions
+    # ------------------------------------------------------------------
+
+    def _open_context_menu(self, pos) -> None:
+        widget = self.sender()
+        item = widget.itemAt(pos) if isinstance(widget, QTreeWidget) else None
+        if not isinstance(item, EntryItem):
+            return
+
+        entry = item.entry
+
+        menu = QMenu(self)
+        extract_action = QAction("Extract…", self)
+        extract_action.triggered.connect(lambda: self._extract_entry(entry))
+        menu.addAction(extract_action)
+
+        copy_name_action = QAction("Copy Name", self)
+        copy_name_action.triggered.connect(lambda: self._copy_text(entry.name))
+        menu.addAction(copy_name_action)
+
+        copy_path_action = QAction("Copy Path", self)
+        copy_path_action.triggered.connect(lambda: self._copy_text(entry.path()))
+        menu.addAction(copy_path_action)
+
+        menu.addSeparator()
+        props_action = QAction("Properties", self)
+        props_action.triggered.connect(lambda: self._show_properties(entry))
+        menu.addAction(props_action)
+
+        viewport = widget.viewport() if isinstance(widget, QTreeWidget) else None
+        if viewport:
+            menu.exec(viewport.mapToGlobal(pos))
+
+    # ------------------------------------------------------------------
+    def _extract_all(self) -> None:
+        if not self.cachefile:
+            return
+        self._extract_entry(self.cachefile.root)
+
+    # ------------------------------------------------------------------
+    def _extract_entry(self, entry) -> None:
+        if not entry:
+            return
+        dest = QFileDialog.getExistingDirectory(self, "Select destination")
+        if not dest:
+            return
+
+        if entry.is_file():
+            files = [entry]
+        else:
+            files = entry.all_files()
+
+        key = None
+        if any(is_encrypted(f) for f in files):
+            text, ok = QInputDialog.getText(self, "Encrypted file", "Enter decryption key:")
+            if not ok or not text:
+                return
+            try:
+                key = bytes.fromhex(text)
+            except ValueError:
+                key = text.encode("utf-8")
+
+        worker = ExtractionWorker(files, dest, key, self)
+        progress = QProgressDialog("Extracting…", "Cancel", 0, 100, self)
+        progress.setWindowModality(Qt.WindowModal)
+        progress.canceled.connect(worker.cancel)
+
+        worker.progress.connect(lambda val, text: (progress.setValue(val), progress.setLabelText(text)))
+        worker.error.connect(lambda msg: QMessageBox.critical(self, "Error", msg))
+        worker.finished.connect(progress.close)
+
+        worker.start()
+        progress.exec()
+
+        if not worker.isRunning():
+            QMessageBox.information(self, "Extraction complete", f"Extracted to {dest}")
+
+    # ------------------------------------------------------------------
+    def _copy_text(self, text: str) -> None:
+        """Copy arbitrary text to the clipboard and update the status bar."""
+
+        QApplication.clipboard().setText(text)
+        self.statusBar().showMessage(f"Copied: {text}", 3000)
+
+    # ------------------------------------------------------------------
+    def _show_properties(self, entry) -> None:
+        if not entry:
+            return
+        dialog = PropertiesDialog(entry, self)
+        dialog.exec()
+
+    # ------------------------------------------------------------------
+    def _defragment(self) -> None:
+        """Run a lightweight fragmentation check.
+
+        The Python port does not currently support rewriting cache files, but
+        we mimic the behaviour of GCFScape by informing the user whether the
+        archive appears fragmented.
+        """
+
+        if not self.cachefile:
+            return
+
+        if not self.cachefile.is_fragmented():
+            QMessageBox.information(self, "Defragment", "Archive is already defragmented.")
+            return
+
+        QMessageBox.warning(
+            self,
+            "Defragment",
+            "This archive appears fragmented.  Defragmentation is not yet implemented in this Python port.",
+        )
+
+    # ------------------------------------------------------------------
+    def _validate(self) -> None:
+        """Validate the currently loaded archive and report any errors."""
+
+        if not self.cachefile:
+            return
+
+        errors = self.cachefile.validate()
+        if errors:
+            text = "\n".join(errors[:20])
+            QMessageBox.warning(
+                self,
+                "Validate",
+                f"Problems were detected in the archive:\n{text}",
+            )
+        else:
+            QMessageBox.information(
+                self,
+                "Validate",
+                "Archive appears to be valid.",
+            )
+
+    # ------------------------------------------------------------------
+    def _convert_gcf(self, target_version: int) -> None:
+        """Convert the loaded GCF to a given format version."""
+
+        if not self.cachefile or not self.cachefile.is_gcf():
+            QMessageBox.warning(self, "Convert", "No GCF archive loaded.")
+            return
+
+        default = os.path.splitext(self.cachefile.filename)[0] + f"_v{target_version}.gcf"
+        path, _ = QFileDialog.getSaveFileName(self, "Save Converted GCF", default, "GCF Files (*.gcf)")
+        if not path:
+            return
+        try:
+            self.cachefile.convert_version(target_version, path)
+            QMessageBox.information(self, "Convert", "Conversion completed.")
+        except NotImplementedError:
+            QMessageBox.warning(self, "Convert", "Conversion is not yet implemented in this build.")
+        except Exception as exc:
+            QMessageBox.critical(self, "Convert", f"Conversion failed: {exc}")
+
+    # ------------------------------------------------------------------
+    def _open_options(self) -> None:
+        dialog = OptionsDialog(self.settings, self)
+        if dialog.exec() == QDialog.Accepted:
+            self.preview_toggle_action.setChecked(dialog.preview_enabled)
+
+    # ------------------------------------------------------------------
+    def _about(self) -> None:
+        QMessageBox.about(
+            self,
+            "About GCFScape (Python)",
+            "<b>GCFScape (Python Edition)</b><br>"
+            "A Qt based reimplementation of the classic GCFScape tool.",
+        )
+
+    # ------------------------------------------------------------------
+    # Event handling
+    # ------------------------------------------------------------------
+
+    def closeEvent(self, event: QCloseEvent) -> None:  # type: ignore[override]
+        if self.cachefile:
+            res = QMessageBox.question(
+                self,
+                "Quit",
+                "Close the current archive and exit?",
+                QMessageBox.Yes | QMessageBox.No,
+            )
+            if res != QMessageBox.Yes:
+                event.ignore()
+                return
+        event.accept()
+
+
+# ---------------------------------------------------------------------------
+# Application entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: List[str] | None = None) -> int:
+    """Run the GUI application."""
+
+    app = QApplication(argv or sys.argv)
+    window = GCFScapeWindow()
+    window.show()
+    return app.exec_()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    raise SystemExit(main())
+

--- a/pysteam/blob.py
+++ b/pysteam/blob.py
@@ -4,9 +4,9 @@ import pprint
 import struct
 import zlib
 
-from cStringIO import StringIO
+from io import BytesIO
 
-class Blob(object):
+class Blob:
     MAGIC = 0x5001
     COMPRESSED_MAGIC = 0x4301
 
@@ -36,13 +36,13 @@ class Blob(object):
             compressed_bytes = stream.read(compressed_len)
             decompressed_bytes = zlib.decompress(compressed_bytes)
 
-            self.parse(StringIO(decompressed_bytes))
+            self.parse(BytesIO(decompressed_bytes))
 
     def serialize(self, compress=True):
         mode = Blob.COMPRESSED_MAGIC if compress else Blob.MAGIC
-        data = StringIO()
+        data = BytesIO()
 
-        for node in self.children.itervalues():
+        for node in self.children.values():
             data.write(node.serialize())
 
         if compress:
@@ -56,14 +56,14 @@ class Blob(object):
         return len(self.children)
 
     def __iter__(self):
-        return self.children.itervalues()
+        return iter(self.children.values())
 
     def __getitem__(self, key):
         if isinstance(key, int):
             key = struct.pack("<L", key)
         return self.children[key]
 
-class BlobNode(object):
+class BlobNode:
     def __init__(self):
         self.key = None
         self.data = None
@@ -80,7 +80,7 @@ class BlobNode(object):
         magic, = struct.unpack("<H", self.data[:2])
         if magic in (Blob.MAGIC, Blob.COMPRESSED_MAGIC):
             self.child = Blob()
-            self.child.parse(StringIO(self.data))
+            self.child.parse(BytesIO(self.data))
 
     def serialize(self):
         if self.child is not None:

--- a/pysteam/bsp/__init__.py
+++ b/pysteam/bsp/__init__.py
@@ -1,0 +1,33 @@
+"""Utilities for working with BSP map files.
+
+This module exposes helpers used by the GUI preview widget to detect whether
+an arbitrary ``.bsp`` file belongs to the classic Goldsource engine or the
+newer Source engine.  The detection is intentionally lightweight so it can be
+performed on in-memory data extracted from Steam cache files without writing to
+disk.
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import Literal
+
+Engine = Literal["goldsource", "source"]
+
+
+def detect_engine(data: bytes) -> Engine:
+    """Return the engine family for ``data`` representing a BSP file.
+
+    Goldsource maps begin directly with a 32-bit integer version (30).  Source
+    maps prefix the header with the magic string ``VBSP`` followed by a
+    version number.  Any unrecognised headers default to ``"source"`` so that
+    more modern BSP flavours still render using the Source path.
+    """
+
+    if data[:4] == b"VBSP":
+        return "source"
+
+    version, = struct.unpack("<I", data[:4])
+    if version == 30:
+        return "goldsource"
+    return "source"

--- a/pysteam/bsp/preview.py
+++ b/pysteam/bsp/preview.py
@@ -1,0 +1,112 @@
+"""Qt widget capable of rendering a top-down preview of BSP maps.
+
+The widget relies on the :mod:`bsp_tool` package to parse both Goldsource and
+Source engine map formats.  Geometry is rendered using simple 2D line drawing
+via :class:`PyQt5.QtGui.QPainter`, providing a lightweight preview that works
+in headless environments and does not require an OpenGL context.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from typing import List, Sequence, Tuple
+
+from PyQt5.QtCore import QPointF, Qt
+from PyQt5.QtGui import QPainter, QPixmap
+from PyQt5.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+from . import detect_engine
+
+try:  # pragma: no cover - optional dependency
+    import bsp_tool
+except Exception:  # pragma: no cover - if unavailable the widget will display an error
+    bsp_tool = None  # type: ignore
+
+
+class BSPViewWidget(QWidget):
+    """Widget displaying a very small top-down preview of a BSP map."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.label = QLabel("No preview")
+        self.label.setAlignment(Qt.AlignCenter)
+        layout.addWidget(self.label)
+
+    # ------------------------------------------------------------------
+    def clear(self) -> None:
+        self.label.setText("No preview")
+        self.label.setPixmap(QPixmap())
+
+    # ------------------------------------------------------------------
+    def load_map(self, data: bytes) -> None:
+        """Render ``data`` representing a BSP file into the label."""
+
+        if not bsp_tool:
+            self.label.setText("bsp_tool module missing")
+            return
+
+        engine = detect_engine(data)
+        self.label.setToolTip(f"{engine} engine")
+
+        # ``bsp_tool`` expects a file path.  Write to a temporary file and parse
+        # it, then immediately remove the file once loaded.
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".bsp") as tmp:
+            tmp.write(data)
+            tmp_path = tmp.name
+        try:
+            bsp = bsp_tool.load_bsp(tmp_path)
+        finally:
+            os.unlink(tmp_path)
+
+        # Gather geometry as a list of polygons, each polygon being a sequence
+        # of ``(x, y)`` tuples.  The logic mirrors the approach used by both
+        # reference viewers with minimal abstraction.
+        vertices: Sequence = bsp.VERTICES
+        surf_edges: Sequence[int] = bsp.SURFEDGES
+        edges: Sequence[Tuple[int, int]] = bsp.EDGES
+        faces: Sequence = bsp.FACES
+
+        polygons: List[List[Tuple[float, float]]] = []
+        for face in faces:
+            start = getattr(face, "first_edge", getattr(face, "firstEdge", 0))
+            length = getattr(face, "num_edges", getattr(face, "numEdges", 0))
+            indices: List[int] = []
+            for i in range(length):
+                e_index = surf_edges[start + i]
+                if e_index < 0:
+                    edge = edges[-e_index][::-1]
+                else:
+                    edge = edges[e_index]
+                indices.append(edge[0])
+            polygon = [(vertices[i].x, vertices[i].y) for i in indices]
+            polygons.append(polygon)
+
+        if not polygons:
+            self.label.setText(f"No geometry ({engine})")
+            return
+
+        xs = [x for poly in polygons for x, _ in poly]
+        ys = [y for poly in polygons for _, y in poly]
+        min_x, max_x = min(xs), max(xs)
+        min_y, max_y = min(ys), max(ys)
+        width = max_x - min_x or 1.0
+        height = max_y - min_y or 1.0
+
+        pixmap = QPixmap(self.width() or 400, self.height() or 300)
+        pixmap.fill(Qt.black)
+        painter = QPainter(pixmap)
+        painter.setPen(Qt.white)
+        scale = min((pixmap.width() - 20) / width, (pixmap.height() - 20) / height)
+        for poly in polygons:
+            pts = [
+                QPointF((x - min_x) * scale + 10, (max_y - y) * scale + 10)
+                for x, y in poly
+            ]
+            for i in range(len(pts)):
+                painter.drawLine(pts[i], pts[(i + 1) % len(pts)])
+        painter.end()
+
+        self.label.setPixmap(pixmap)

--- a/pysteam/cdr/models.py
+++ b/pysteam/cdr/models.py
@@ -7,7 +7,7 @@ from pysteam.blob import Blob
 class ParseError(Exception):
     pass
 
-class CDR(object):
+class CDR:
     CURRENT_VER = 10
 
     def parse(self, stream):
@@ -41,7 +41,7 @@ class CDR(object):
 ### Application
 ################################
 
-class Application(object):
+class Application:
     def __str__(self):
         return "%s (App ID %d): %s" % ("Cache File" if self.is_cache() else "Application", self.app_id, self.app_name)
 
@@ -106,15 +106,15 @@ class Application(object):
             tempblob.parse(n)
             self.user_defined_records.append(tempblob)
 
-class ApplicationLaunchOptionRecord(object):
+class ApplicationLaunchOptionRecord:
     def __str__(self):
-        return "%s's Launch Option Record %d" % (unicode(self.owner), self.option_id)
+        return "%s's Launch Option Record %d" % (str(self.owner), self.option_id)
 
     def parse(self, node):
 
         blob = node.child
         if len(blob.children) == 0:
-            raise ValueError, "Blob has no children"
+            raise ValueError("Blob has no children")
         self.option_id = struct.unpack("<l", node.key)[0]
 
         self.description = node[1].data
@@ -124,9 +124,9 @@ class ApplicationLaunchOptionRecord(object):
         self.no_start_menu_shortcut = bytes_as_bool(node[5].data)
         self.long_running_unattended = bytes_as_bool(node[6].data)
 
-class ApplicationVersionRecord(object):
+class ApplicationVersionRecord:
     def __str__(self):
-        return "%s's Version Record %d" % (unicode(self.owner), self.version_id)
+        return "%s's Version Record %d" % (str(self.owner), self.version_id)
 
     def parse(self, node):
         self.version_id = struct.unpack("<l", node.key)[0]
@@ -146,14 +146,14 @@ class ApplicationVersionRecord(object):
             tempblob.owner = self
             tempblob.parse(n)
 
-class ApplicationVersionLaunchRecord(object):
+class ApplicationVersionLaunchRecord:
     def __str__(self):
         return "%s: Version %d's Launch Record %d" % (self.owner.owner, self.owner.version_id, self.launch_option_id)
 
     def parse(self, node):
         self.launch_option_id = struct.unpack("<l", node.key)[0]
 
-class ApplicationFilesystemRecord(object):
+class ApplicationFilesystemRecord:
     def get_mount_name(self):
         if len(self.mount_name) > 0:
             return self.mount_name
@@ -161,16 +161,16 @@ class ApplicationFilesystemRecord(object):
             return Application.objects.get(app_id=self.app_id).get_mount_name()
 
     def __str__(self):
-        return "%s: Cache import: %s" % (unicode(self.owner), self.get_mount_name())
+        return "%s: Cache import: %s" % (str(self.owner), self.get_mount_name())
 
     def parse(self, node):
         self.app_id = struct.unpack("<l", node[1].data)[0]
         self.mount_name = node[2].data
         self.is_optional = bytes_as_bool(node[3].data)
 
-class ApplicationUserDefinedRecord(object):
+class ApplicationUserDefinedRecord:
     def __str__(self):
-        return "%s: User Defined Record" % unicode(self.owner)
+        return "%s: User Defined Record" % str(self.owner)
 
     def parse(self, node):
         self.key = node.key

--- a/pysteam/fs/__init__.py
+++ b/pysteam/fs/__init__.py
@@ -1,7 +1,7 @@
 
 import os
 
-class DirectoryFile(object):
+class DirectoryFile:
     def __init__(self, folder, name="", package=None):
         self.folder = folder
         self.name = name
@@ -10,11 +10,11 @@ class DirectoryFile(object):
     def size(self):
         return self.package._size(self)
 
-    def open(self, mode="rb"):
-        return self.package._open_file(self, mode)
+    def open(self, mode="rb", key=None):
+        return self.package._open_file(self, mode, key)
 
-    def extract(self, where, keep_folder_structure=True):
-        return self.package._extract_file(self, where, keep_folder_structure)
+    def extract(self, where, keep_folder_structure=True, key=None):
+        return self.package._extract_file(self, where, keep_folder_structure, key)
 
     def is_file(self):
         # Yep. We are a file. Peek at the class name if you need to.
@@ -30,7 +30,7 @@ class DirectoryFile(object):
     def sys_path(self):
         return os.path.join(self.folder.sys_path(), self.name)
 
-class DirectoryFolder(object):
+class DirectoryFolder:
     def __init__(self, parent, name="", package=None):
         self.owner = parent
         self.name = name
@@ -41,7 +41,7 @@ class DirectoryFolder(object):
         return self.items[name]
 
     def __iter__(self):
-        return self.items.itervalues()
+        return iter(self.items.values())
 
     def __len__(self):
         return len(self.items)
@@ -49,8 +49,8 @@ class DirectoryFolder(object):
     def size(self):
         return sum(i.size() for i in self.items)
 
-    def extract(self, where, recursive=False, keep_folder_structure=True, filter=None):
-        return self.package._extract_folder(self, where, recursive, keep_folder_structure, filter)
+    def extract(self, where, recursive=False, keep_folder_structure=True, filter=None, key=None):
+        return self.package._extract_folder(self, where, recursive, keep_folder_structure, filter, key)
 
     def is_file(self):
         return False
@@ -85,7 +85,7 @@ class DirectoryFolder(object):
 
         return files
 
-class FilesystemPackage(object):
+class FilesystemPackage:
 
     def parse(self, dirname):
         rootpath = os.path.abspath(dirname)
@@ -113,7 +113,7 @@ class FilesystemPackage(object):
     def _size(self, entry):
         return os.path.getsize(entry.sys_path())
 
-    def _open_file(self, entry, mode):
+    def _open_file(self, entry, mode, key=None):
         return open(entry.sys_path(), mode)
 
     def _extract_file(self, *a, **b):

--- a/pysteam/image/__init__.py
+++ b/pysteam/image/__init__.py
@@ -1,0 +1,4 @@
+"""Generic image helpers."""
+from .preview import ImageViewWidget
+
+__all__ = ["ImageViewWidget"]

--- a/pysteam/image/preview.py
+++ b/pysteam/image/preview.py
@@ -1,0 +1,38 @@
+"""Generic image preview widget using Qt's image plugins."""
+from __future__ import annotations
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QImage, QPixmap
+from PyQt5.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+
+class ImageViewWidget(QWidget):
+    """Widget displaying standard image formats.
+
+    The widget relies solely on Qt's built-in image plugins so formats such as
+    GIF, JPEG, BMP, PNG, TGA and ICO are supported without external
+    dependencies.
+    """
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.label = QLabel("No preview")
+        self.label.setAlignment(Qt.AlignCenter)
+        layout.addWidget(self.label)
+
+    # ------------------------------------------------------------------
+    def clear(self) -> None:
+        self.label.setText("No preview")
+        self.label.setPixmap(QPixmap())
+
+    # ------------------------------------------------------------------
+    def load_image(self, data: bytes) -> None:
+        image = QImage.fromData(data)
+        if image.isNull():
+            self.label.setText("Unsupported image format")
+            self.label.setPixmap(QPixmap())
+            return
+        self.label.setPixmap(QPixmap.fromImage(image))
+        self.label.setToolTip(f"{image.width()}x{image.height()} image")

--- a/pysteam/mdl/__init__.py
+++ b/pysteam/mdl/__init__.py
@@ -1,0 +1,31 @@
+"""Utilities for Valve MDL model files.
+
+This module provides a small helper to detect whether a given MDL file was
+built for the Goldsource or Source engine.  The logic is intentionally light
+weight and only inspects the header magic and version which is sufficient for
+preview purposes.
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import Literal
+
+EngineType = Literal["Goldsrc", "Source", "Unknown"]
+
+def detect_engine(data: bytes) -> EngineType:
+    """Return the engine type for ``data`` representing an MDL file.
+
+    Both Goldsource and Source engine models begin with the magic ``IDST``.
+    Goldsource models use version ``10`` (and below) while Source engine models
+    typically start at version ``44`` and above.  Any other combination is
+    reported as ``Unknown``.
+    """
+    if len(data) < 8:
+        return "Unknown"
+    magic, version = struct.unpack_from("<4sI", data)
+    if magic != b"IDST":
+        return "Unknown"
+    if version <= 10:
+        return "Goldsrc"
+    return "Source"

--- a/pysteam/mdl/preview.py
+++ b/pysteam/mdl/preview.py
@@ -1,0 +1,97 @@
+"""Qt widget that draws a simple preview of Valve MDL models.
+
+The implementation is intentionally lightweight – it does not attempt to render
+textured meshes or support camera interaction.  Instead it reads the model
+bounding box from the MDL header and draws a wireframe rectangle representing
+the front view.  This mirrors the minimalist preview behaviour in other parts
+of the application and keeps the dependency footprint small.
+
+When a model is selected the widget automatically detects whether it targets the
+Goldsource or Source engine and adjusts the bounding box offsets accordingly.
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import Tuple
+
+from PyQt5.QtCore import QPointF, Qt
+from PyQt5.QtGui import QPainter, QPixmap
+from PyQt5.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+from . import detect_engine
+
+Vector = Tuple[float, float, float]
+
+class MDLViewWidget(QWidget):
+    """Widget capable of displaying a crude MDL preview."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.label = QLabel("No preview")
+        self.label.setAlignment(Qt.AlignCenter)
+        layout.addWidget(self.label)
+
+    # ------------------------------------------------------------------
+    def clear(self) -> None:
+        self.label.setText("No preview")
+        self.label.setPixmap(QPixmap())
+
+    # ------------------------------------------------------------------
+    def load_model(self, data: bytes) -> None:
+        """Render ``data`` containing an MDL model into the label."""
+
+        engine = detect_engine(data)
+        bbox = None
+        if engine == "Goldsrc":
+            bbox = self._goldsrc_bounds(data)
+        elif engine == "Source":
+            bbox = self._source_bounds(data)
+        if bbox is None:
+            self.label.setText("Unsupported MDL")
+            return
+        self.label.setToolTip(f"{engine} model")
+        (min_x, min_y, min_z), (max_x, max_y, max_z) = bbox
+        width = max_x - min_x or 1.0
+        height = max_z - min_z or 1.0
+        pixmap = QPixmap(self.width() or 300, self.height() or 300)
+        pixmap.fill(Qt.black)
+        painter = QPainter(pixmap)
+        painter.setPen(Qt.white)
+        scale = min((pixmap.width() - 20) / width, (pixmap.height() - 20) / height)
+        def map_pt(x: float, z: float) -> QPointF:
+            return QPointF((x - min_x) * scale + 10, (max_z - z) * scale + 10)
+        pts = [
+            map_pt(min_x, min_z),
+            map_pt(max_x, min_z),
+            map_pt(max_x, max_z),
+            map_pt(min_x, max_z),
+        ]
+        for i in range(len(pts)):
+            painter.drawLine(pts[i], pts[(i + 1) % len(pts)])
+        painter.end()
+        self.label.setPixmap(pixmap)
+
+    # ------------------------------------------------------------------
+    def _goldsrc_bounds(self, data: bytes) -> Tuple[Vector, Vector] | None:
+        """Return bounding box for a Goldsource model."""
+
+        # Offsets taken from ``studiohdr_t`` in the Goldsource SDK.
+        if len(data) < 136:
+            return None
+        bbmin = struct.unpack_from("<3f", data, 112)
+        bbmax = struct.unpack_from("<3f", data, 124)
+        return bbmin, bbmax
+
+    # ------------------------------------------------------------------
+    def _source_bounds(self, data: bytes) -> Tuple[Vector, Vector] | None:
+        """Return bounding box for a Source engine model."""
+
+        # Offsets taken from ``studiohdr_t`` in the Source SDK.
+        if len(data) < 152:
+            return None
+        bbmin = struct.unpack_from("<3f", data, 128)
+        bbmax = struct.unpack_from("<3f", data, 140)
+        return bbmin, bbmax

--- a/pysteam/registry.py
+++ b/pysteam/registry.py
@@ -2,7 +2,7 @@
 from pysteam.blob import Blob
 import struct
 
-class Registry(object):
+class Registry:
 
     def __init__(self):
         self.root = None
@@ -26,7 +26,7 @@ class Registry(object):
     def __iter__(self):
         return iter(self.root)
 
-class RegistryKey(object):
+class RegistryKey:
     def __init__(self, registry, owner):
         self.owner = owner
         self.registry = registry
@@ -54,9 +54,9 @@ class RegistryKey(object):
         return repr(self.items)
 
     def __iter__(self):
-        return self.items.itervalues()
+        return iter(self.items.values())
 
-class RegistryValue(object):
+class RegistryValue:
 
     TYPE_STRING = 0
     TYPE_DWORD = 1

--- a/pysteam/util.py
+++ b/pysteam/util.py
@@ -1,9 +1,11 @@
 
 import datetime
 import struct
+import time as time_module
 
-def bytes_as_bool(data):
-    return all(x != "\0" for x in data)
+
+def bytes_as_bool(data: bytes) -> bool:
+    return all(b != 0 for b in data)
 
 # Host (IP and Port) encoding and decoding
 # Little endian for some reason...
@@ -20,10 +22,11 @@ def decode_host(data):
     port, = struct.unpack("<H", data[4:])
     return (ip, port)
 
-def py_time(time):
-    unix = (time / 1000000) - 62135596800
-    microseconds = time % 1000000
+def py_time(raw_time: int) -> datetime.datetime:
+    unix = (raw_time / 1_000_000) - 62135596800
+    microseconds = raw_time % 1_000_000
     return datetime.datetime.fromtimestamp(unix) - datetime.timedelta(0, 0, microseconds)
 
-def steam_time(time):
-    return (time.mktime(time) + 62135596800) * 1000000
+
+def steam_time(tm) -> int:
+    return (time_module.mktime(tm) + 62135596800) * 1_000_000

--- a/pysteam/vtf/__init__.py
+++ b/pysteam/vtf/__init__.py
@@ -1,0 +1,6 @@
+"""Utilities for reading and previewing VTF (Valve Texture Format) files."""
+
+from .reader import VTFFile
+from .preview import VTFViewWidget
+
+__all__ = ["VTFFile", "VTFViewWidget"]

--- a/pysteam/vtf/dxt.py
+++ b/pysteam/vtf/dxt.py
@@ -1,0 +1,109 @@
+"""DXT texture decompression in pure Python."""
+from __future__ import annotations
+
+from typing import List, Tuple
+
+
+def _color565_to_rgba(c565: int) -> Tuple[int, int, int, int]:
+    """Convert 5:6:5 RGB value to 8-bit RGBA tuple."""
+    r = ((c565 >> 11) & 0x1F) * 255 // 31
+    g = ((c565 >> 5) & 0x3F) * 255 // 63
+    b = (c565 & 0x1F) * 255 // 31
+    return r, g, b, 255
+
+
+def _decode_dxt1_block(block: bytes) -> List[Tuple[int, int, int, int]]:
+    """Decode a single 4x4 DXT1 block into a list of RGBA tuples."""
+    color0 = block[0] | (block[1] << 8)
+    color1 = block[2] | (block[3] << 8)
+    c0 = _color565_to_rgba(color0)
+    c1 = _color565_to_rgba(color1)
+    colors = [c0, c1]
+    if color0 > color1:
+        colors.append(tuple((2 * c0[i] + c1[i]) // 3 for i in range(4)))
+        colors.append(tuple((c0[i] + 2 * c1[i]) // 3 for i in range(4)))
+    else:
+        colors.append(tuple((c0[i] + c1[i]) // 2 for i in range(4)))
+        colors.append((0, 0, 0, 0))
+    result: List[Tuple[int, int, int, int]] = []
+    codes = block[4:8]
+    for row in range(4):
+        code_row = codes[row]
+        for col in range(4):
+            code = (code_row >> (col * 2)) & 0x03
+            result.append(colors[code])
+    return result
+
+
+def decode_dxt1(data: bytes, width: int, height: int) -> bytes:
+    """Decode a DXT1 image to RGBA bytes."""
+    out = bytearray(width * height * 4)
+    offset = 0
+    for y in range(0, height, 4):
+        for x in range(0, width, 4):
+            block = data[offset:offset + 8]
+            offset += 8
+            colors = _decode_dxt1_block(block)
+            for by in range(4):
+                for bx in range(4):
+                    px = x + bx
+                    py = y + by
+                    if px >= width or py >= height:
+                        continue
+                    idx = (py * width + px) * 4
+                    out[idx:idx + 4] = bytes(colors[by * 4 + bx])
+    return bytes(out)
+
+
+def _decode_dxt5_alpha(block: bytes) -> List[int]:
+    """Return a list of 16 alpha values decoded from a DXT5 alpha block."""
+    a0 = block[0]
+    a1 = block[1]
+    bits = int.from_bytes(block[2:8], "little")
+    alphas = [0] * 16
+    table = [a0, a1]
+    if a0 > a1:
+        for i in range(1, 7):
+            table.append(((7 - i) * a0 + i * a1) // 7)
+    else:
+        for i in range(1, 5):
+            table.append(((5 - i) * a0 + i * a1) // 5)
+        table.extend([0, 255])
+    for i in range(16):
+        code = (bits >> (i * 3)) & 0x7
+        alphas[i] = table[code]
+    return alphas
+
+
+def decode_dxt5(data: bytes, width: int, height: int) -> bytes:
+    """Decode a DXT5 image to RGBA bytes including alpha."""
+    out = bytearray(width * height * 4)
+    offset = 0
+    for y in range(0, height, 4):
+        for x in range(0, width, 4):
+            alpha_block = data[offset:offset + 8]
+            offset += 8
+            color_block = data[offset:offset + 8]
+            offset += 8
+            colors = _decode_dxt1_block(color_block)
+            alphas = _decode_dxt5_alpha(alpha_block)
+            for by in range(4):
+                for bx in range(4):
+                    px = x + bx
+                    py = y + by
+                    if px >= width or py >= height:
+                        continue
+                    idx = (py * width + px) * 4
+                    color = list(colors[by * 4 + bx])
+                    color[3] = alphas[by * 4 + bx]
+                    out[idx:idx + 4] = bytes(color)
+    return bytes(out)
+
+
+def decode_dxt(data: bytes, fmt: int, width: int, height: int) -> bytes:
+    """Decode DXT1 or DXT5 data based on ``fmt``."""
+    if fmt == 0x0D:
+        return decode_dxt1(data, width, height)
+    if fmt == 0x0F:
+        return decode_dxt5(data, width, height)
+    raise ValueError(f"Unsupported DXT format: {fmt:#x}")

--- a/pysteam/vtf/preview.py
+++ b/pysteam/vtf/preview.py
@@ -1,0 +1,37 @@
+"""Qt widget capable of displaying VTF textures."""
+from __future__ import annotations
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QImage, QPixmap
+from PyQt5.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+from .reader import VTFFile
+
+
+class VTFViewWidget(QWidget):
+    """Widget displaying the first frame/mip of a VTF texture."""
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        self.label = QLabel("No preview")
+        self.label.setAlignment(Qt.AlignCenter)
+        layout.addWidget(self.label)
+
+    # ------------------------------------------------------------------
+    def clear(self) -> None:
+        self.label.setText("No preview")
+        self.label.setPixmap(QPixmap())
+
+    # ------------------------------------------------------------------
+    def load_vtf(self, data: bytes) -> None:
+        try:
+            vtf = VTFFile(data)
+            w, h, pixels = vtf.get_image()
+            image = QImage(pixels, w, h, QImage.Format_RGBA8888)
+            self.label.setPixmap(QPixmap.fromImage(image))
+            self.label.setToolTip(f"{w}x{h} VTF")
+        except Exception as exc:  # pragma: no cover - user feedback
+            self.label.setText(str(exc))
+            self.label.setPixmap(QPixmap())

--- a/pysteam/vtf/reader.py
+++ b/pysteam/vtf/reader.py
@@ -1,0 +1,197 @@
+"""Pure Python VTF (Valve Texture Format) reader."""
+from __future__ import annotations
+
+import io
+import struct
+from dataclasses import dataclass
+from typing import BinaryIO, Tuple
+
+from .dxt import decode_dxt
+
+
+@dataclass
+class VTFHeader:
+    sig: bytes
+    version: Tuple[int, int]
+    header_size: int
+    width: int
+    height: int
+    flags: int
+    frame_count: int
+    first_frame: int
+    reflectivity: Tuple[float, float, float]
+    bumpmap_scale: float
+    high_fmt: int
+    mipmap_count: int
+    low_fmt: int
+    low_width: int
+    low_height: int
+    depth: int
+    resource_count: int
+
+
+def _read_uint(fp: BinaryIO) -> int:
+    return struct.unpack('<I', fp.read(4))[0]
+
+
+def _read_ushort(fp: BinaryIO) -> int:
+    return struct.unpack('<H', fp.read(2))[0]
+
+
+def _read_byte(fp: BinaryIO) -> int:
+    return struct.unpack('<B', fp.read(1))[0]
+
+
+def read_header(fp: BinaryIO) -> VTFHeader:
+    sig = fp.read(4)
+    if sig != b"VTF\0":
+        raise ValueError("Invalid VTF signature")
+    version = struct.unpack('<II', fp.read(8))
+    header_size = _read_uint(fp)
+    width = _read_ushort(fp)
+    height = _read_ushort(fp)
+    flags = _read_uint(fp)
+    frame_count = _read_ushort(fp) or 1
+    first_frame = _read_ushort(fp)
+    fp.seek(4, 1)
+    reflectivity = struct.unpack('<fff', fp.read(12))
+    fp.seek(4, 1)
+    bumpmap_scale = struct.unpack('<f', fp.read(4))[0]
+    high_fmt = _read_uint(fp)
+    mipmap_count = _read_byte(fp)
+    low_fmt = _read_uint(fp)
+    low_width = _read_byte(fp)
+    low_height = _read_byte(fp)
+    depth = _read_ushort(fp)
+    fp.seek(3, 1)
+    resource_count = _read_uint(fp)
+    fp.seek(8, 1)
+    return VTFHeader(
+        sig=sig,
+        version=version,
+        header_size=header_size,
+        width=width,
+        height=height,
+        flags=flags,
+        frame_count=frame_count,
+        first_frame=first_frame,
+        reflectivity=reflectivity,
+        bumpmap_scale=bumpmap_scale,
+        high_fmt=high_fmt,
+        mipmap_count=mipmap_count,
+        low_fmt=low_fmt,
+        low_width=low_width,
+        low_height=low_height,
+        depth=depth,
+        resource_count=resource_count,
+    )
+
+
+def ruf(x: int) -> int:
+    return x + ((4 - (x & 3)) & 3)
+
+
+def byte_size_fmt(fmt: int, w: int, h: int) -> int:
+    if fmt in (0x0, 0x1, 0x0B, 0x0C):
+        return w * h * 4
+    if fmt in (0x2, 0x3):
+        return w * h * 3
+    if fmt == 0x0D:
+        return ruf(w) * ruf(h) // 2
+    if fmt in (0x0E, 0x0F):
+        return ruf(w) * ruf(h)
+    raise ValueError(f"Unsupported format {fmt:#x}")
+
+
+def fmt_mip_offset(fmt: int, w: int, h: int, mpm_ct: int, frame_ct: int, mip: int) -> int:
+    offset = 0
+    for i in range(mip + 1, mpm_ct):
+        offset += byte_size_fmt(fmt, w >> i, h >> i) * frame_ct
+    return offset
+
+
+def get_hri_location(fp: BinaryIO, header: VTFHeader) -> int:
+    if header.version[1] == 1:
+        return 0x40 + byte_size_fmt(header.low_fmt, header.low_width, header.low_height)
+    if header.version[1] == 2:
+        return (
+            0x40
+            + byte_size_fmt(header.low_fmt, header.low_width, header.low_height)
+            + 0x10 * header.frame_count
+        )
+    fp.seek(0x50)
+    for _ in range(10):
+        b = fp.read(1)
+        if not b:
+            break
+        if b[0] == 0x30:
+            fp.seek(3, 1)
+            return _read_uint(fp)
+        fp.seek(7, 1)
+    return 0xE8
+
+
+def _decode_raw(data: bytes, fmt: int, w: int, h: int) -> bytes:
+    out = bytearray(w * h * 4)
+    if fmt == 0x0:  # RGBA
+        out[:] = data
+    elif fmt == 0x1:  # ABGR
+        for i in range(w * h):
+            a, b, g, r = data[i * 4 : i * 4 + 4]
+            out[i * 4 : i * 4 + 4] = bytes([r, g, b, a])
+    elif fmt == 0x2:  # RGB
+        for i in range(w * h):
+            r, g, b = data[i * 3 : i * 3 + 3]
+            out[i * 4 : i * 4 + 4] = bytes([r, g, b, 255])
+    elif fmt == 0x3:  # BGR
+        for i in range(w * h):
+            b, g, r = data[i * 3 : i * 3 + 3]
+            out[i * 4 : i * 4 + 4] = bytes([r, g, b, 255])
+    elif fmt == 0x0B:  # ARGB
+        for i in range(w * h):
+            a, r, g, b = data[i * 4 : i * 4 + 4]
+            out[i * 4 : i * 4 + 4] = bytes([r, g, b, a])
+    elif fmt == 0x0C:  # BGRA
+        for i in range(w * h):
+            b, g, r, a = data[i * 4 : i * 4 + 4]
+            out[i * 4 : i * 4 + 4] = bytes([r, g, b, a])
+    else:
+        raise ValueError(f"Unsupported raw format {fmt:#x}")
+    return bytes(out)
+
+
+class VTFFile:
+    """Reader for Valve Texture Format data."""
+
+    def __init__(self, data: bytes) -> None:
+        fp = io.BytesIO(data)
+        self.header = read_header(fp)
+        self.hri_offset = get_hri_location(fp, self.header)
+        fp.seek(0)
+        self.data = fp.read()
+
+    def get_image(self, frame: int = 0, mip: int = 0) -> Tuple[int, int, bytes]:
+        h = self.header
+        if frame >= h.frame_count:
+            raise IndexError("frame out of range")
+        if mip >= h.mipmap_count:
+            raise IndexError("mip level out of range")
+        w = h.width >> mip
+        ht = h.height >> mip
+        offset = self.hri_offset + fmt_mip_offset(h.high_fmt, h.width, h.height, h.mipmap_count, h.frame_count, mip)
+        offset += byte_size_fmt(h.high_fmt, w, ht) * frame
+        size = byte_size_fmt(h.high_fmt, w, ht)
+        block = self.data[offset : offset + size]
+        if h.high_fmt in (0x0D, 0x0F):
+            pixels = decode_dxt(block, h.high_fmt, w, ht)
+        else:
+            pixels = _decode_raw(block, h.high_fmt, w, ht)
+        return w, ht, pixels
+
+    @property
+    def frame_count(self) -> int:
+        return self.header.frame_count
+
+    @property
+    def mipmap_count(self) -> int:
+        return self.header.mipmap_count


### PR DESCRIPTION
## Summary
- add archive fragmentation detection and descriptive defragmentation workflow
- implement content-level validation routine that reports size mismatches or read errors
- add menu stubs for converting GCF archives between legacy and latest versions
- begin implementing `convert_version` with header/table rewriting and data copy support
- map manifest entries across block-entry maps so conversion between legacy and modern GCF versions preserves block indices
- integrate rolling-XOR decryption with key prompts so encrypted GCF entries can be previewed and extracted
- support AES-based decryption and decompression for encrypted GCF data

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python gcfscape_gui.py` *(fails: ModuleNotFoundError: No module named 'PyQt5')*


------
https://chatgpt.com/codex/tasks/task_e_68bce9e29a4083309095870150ebb70a