### PR TITLE
Use postponed evaluation of type hints in cachefile

### DIFF
--- a/pysteam/fs/cachefile.py
+++ b/pysteam/fs/cachefile.py
@@ -1,4 +1,6 @@
 
+from __future__ import annotations
+
 import struct
 import os
 import zlib


### PR DESCRIPTION
## Summary
- prevent runtime evaluation of union type hints on older Python versions

## Testing
- `python -m py_compile pysteam/fs/cachefile.py`
- `python - <<'PY'
from pysteam.fs.cachefile import CacheFile
print('CacheFile imported:', CacheFile)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bdd705aa8883308667364820288900