### PR TITLE
Handle v1 GCF archives lacking checksum data

### DIFF
--- a/pysteam/bsp/preview.py
+++ b/pysteam/bsp/preview.py
@@ -12,6 +12,7 @@ import os
 import tempfile
 from typing import List, Sequence, Tuple
 
+from PyQt5.QtGui import QVector3D
 from PyQt5.QtWidgets import QLabel, QVBoxLayout, QWidget
 
 from . import detect_engine
@@ -31,8 +32,15 @@ except Exception:  # pragma: no cover - missing optional deps
 
 try:  # pragma: no cover - optional dependencies
     import pyqtgraph.opengl as gl  # type: ignore
+    _gl_missing_dep: str | None = None
+except ModuleNotFoundError as exc:  # pragma: no cover - missing optional deps
+    gl = None  # type: ignore
+    # ``pyqtgraph.opengl`` depends on ``PyOpenGL``.  Distinguish between the
+    # two so the user gets a helpful message about which package they need.
+    _gl_missing_dep = "PyOpenGL" if exc.name == "OpenGL" else "pyqtgraph"
 except Exception:  # pragma: no cover - missing optional deps
     gl = None  # type: ignore
+    _gl_missing_dep = "pyqtgraph"
 
 
 class BSPViewWidget(QWidget):
@@ -43,7 +51,8 @@ class BSPViewWidget(QWidget):
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         if gl is None:
-            self.view: QWidget = QLabel("pyqtgraph module missing")
+            missing = _gl_missing_dep or "pyqtgraph"
+            self.view: QWidget = QLabel(f"{missing} module missing")
             layout.addWidget(self.view)
         else:
             self.view = gl.GLViewWidget()
@@ -68,7 +77,8 @@ class BSPViewWidget(QWidget):
             return
         if not gl:
             if isinstance(self.view, QLabel):
-                self.view.setText("pyqtgraph module missing")
+                missing = _gl_missing_dep or "pyqtgraph"
+                self.view.setText(f"{missing} module missing")
             return
         if not np:
             if isinstance(self.view, QLabel):
@@ -126,7 +136,11 @@ class BSPViewWidget(QWidget):
         min_x, max_x = min(xs), max(xs)
         min_y, max_y = min(ys), max(ys)
         min_z, max_z = min(zs), max(zs)
-        center = [(min_x + max_x) / 2, (min_y + max_y) / 2, (min_z + max_z) / 2]
+        center = QVector3D(
+            (min_x + max_x) / 2,
+            (min_y + max_y) / 2,
+            (min_z + max_z) / 2,
+        )
         size = max(max_x - min_x, max_y - min_y, max_z - min_z) or 1.0
 
         self.view.opts["center"] = center

--- a/pysteam/fs/cachefile.py
+++ b/pysteam/fs/cachefile.py
@@ -203,14 +203,18 @@ class CacheFile:
         self.manifest.validate()
 
         # Checksum Map
-        self.checksum_map = CacheFileChecksumMap(self)
-        self.checksum_map.parse(stream)
-        self.checksum_map.validate()
+        if self.header.format_version > 1:
+            self.checksum_map = CacheFileChecksumMap(self)
+            self.checksum_map.parse(stream)
+            self.checksum_map.validate()
+        else:
+            self.checksum_map = None
 
         if self.is_gcf():
             # Data Header.
             self.data_header = CacheFileSectorHeader(self)
-            self.data_header.parse(stream.read(24)) # size of BlockDataHeader (6 longs)
+            header_size = 24 if self.header.format_version > 3 else 20
+            self.data_header.parse(stream.read(header_size), self.header.format_version)
             self.data_header.validate()
 
         self.is_parsed = True
@@ -314,7 +318,8 @@ class CacheFile:
 
             out.write(manifest.serialize())
 
-            out.write(self.checksum_map.serialize())
+            if self.checksum_map is not None:
+                out.write(self.checksum_map.serialize())
 
             if self.data_header is not None:
                 out.write(self.data_header.serialize())
@@ -407,7 +412,8 @@ class CacheFile:
                 out.write(self.block_entry_map.serialize())
             out.write(self.manifest.header_data)
             out.write(self.manifest.manifest_stream.getvalue())
-            out.write(self.checksum_map.serialize())
+            if self.checksum_map is not None:
+                out.write(self.checksum_map.serialize())
 
             self.data_header.first_sector_offset = out.tell() + 24
             out.write(self.data_header.serialize())
@@ -655,8 +661,11 @@ class CacheFile:
         ):
             return None  # Can't validate encrypted data, assume OK.
 
-        if manifest_entry.checksum_index == 0xFFFFFFFF:
-            return None  # No checksum to validate against.
+        if (
+            self.checksum_map is None
+            or manifest_entry.checksum_index == 0xFFFFFFFF
+        ):
+            return None  # No checksum information available.
 
         try:
             count, first = self.checksum_map.entries[manifest_entry.checksum_index]
@@ -956,18 +965,24 @@ class CacheFileAllocationTable:
         (self.sector_count,
          self.first_unused_entry,
          self.is_long_terminator) = struct.unpack("<3L", stream.read(12))
-        self.checksum = sum(stream.read(4))
+        # Checksum is stored as the sum of the three header fields rather
+        # than a byte-wise sum of the structure.  The previous implementation
+        # incorrectly summed the raw bytes which caused validation failures on
+        # legitimate v1 GCF files.
+        (self.checksum,) = struct.unpack("<L", stream.read(4))
 
-        self.terminator = 0xFFFFFFFF if self.owner.alloc_table.is_long_terminator == 1 else 0xFFFF
+        self.terminator = 0xFFFFFFFF if self.is_long_terminator else 0xFFFF
         self.entries = unpack_dword_list(stream, self.sector_count)
 
     def serialize(self):
         data = struct.pack("<3L", self.sector_count, self.first_unused_entry, self.is_long_terminator)
-        self.checksum = sum(data)
+        # Cache the checksum so subsequent calls to ``serialize`` or
+        # ``calculate_checksum`` are in agreement with the on-disk format.
+        self.checksum = self.sector_count + self.first_unused_entry + self.is_long_terminator
         return data + struct.pack("<L", self.checksum) + pack_dword_list(self.entries)
 
     def calculate_checksum(self):
-        return sum(self.serialize()[:12])
+        return self.sector_count + self.first_unused_entry + self.is_long_terminator
 
     def validate(self):
         if self.owner.header.sector_count != self.sector_count:
@@ -1236,18 +1251,41 @@ class CacheFileSectorHeader:
 
     def __init__(self, owner):
         self.owner = owner
+        self.format_version = owner.header.format_version
 
-    def parse(self, data):
-        (self.application_version,
-         self.sector_count,
-         self.sector_size,
-         self.first_sector_offset,
-         self.sectors_used,
-         self.checksum) = struct.unpack("<6L", data)
-
+    def parse(self, data, format_version):
+        self.format_version = format_version
+        if format_version <= 3:
+            (
+                self.sector_count,
+                self.sector_size,
+                self.first_sector_offset,
+                self.sectors_used,
+                self.checksum,
+            ) = struct.unpack("<5L", data)
+            # Older GCF versions omit the application version field.
+            self.application_version = self.owner.header.application_version
+        else:
+            (
+                self.application_version,
+                self.sector_count,
+                self.sector_size,
+                self.first_sector_offset,
+                self.sectors_used,
+                self.checksum,
+            ) = struct.unpack("<6L", data)
 
     def serialize(self):
         self.checksum = self.calculate_checksum()
+        if self.format_version <= 3:
+            return struct.pack(
+                "<5L",
+                self.sector_count,
+                self.sector_size,
+                self.first_sector_offset,
+                self.sectors_used,
+                self.checksum,
+            )
         return struct.pack(
             "<6L",
             self.application_version,
@@ -1259,14 +1297,25 @@ class CacheFileSectorHeader:
         )
 
     def validate(self):
-        if self.application_version != self.owner.header.application_version:
-            raise ValueError("Invalid Cache File Sector Header [ApplicationVersion mismatch]")
+        if (
+            self.format_version > 3
+            and self.application_version != self.owner.header.application_version
+        ):
+            raise ValueError(
+                "Invalid Cache File Sector Header [ApplicationVersion mismatch]"
+            )
         if self.sector_count != self.owner.header.sector_count:
-            raise ValueError("Invalid Cache File Sector Header [SectorCount mismatch]")
+            raise ValueError(
+                "Invalid Cache File Sector Header [SectorCount mismatch]"
+            )
         if self.sector_size != self.owner.header.sector_size:
-            raise ValueError("Invalid Cache File Sector Header [SectorSize mismatch]")
+            raise ValueError(
+                "Invalid Cache File Sector Header [SectorSize mismatch]"
+            )
         if self.checksum != self.calculate_checksum():
-            raise ValueError("Invalid Cache File Sector Header [Checksum mismatch]")
+            raise ValueError(
+                "Invalid Cache File Sector Header [Checksum mismatch]"
+            )
 
     def calculate_checksum(self):
         return self.sector_count + self.sector_size + self.first_sector_offset + self.sectors_used


### PR DESCRIPTION
## Summary
- Skip checksum map for version 1 GCF files and size data headers by format
- Guard conversion, defragmentation, and validation when checksums are missing
- Support legacy GCF sector headers without an application version field
- Interpret allocation table checksum as the sum of header fields to prevent false validation errors

## Testing
- `python -m py_compile pysteam/fs/cachefile.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be0175853c833080252776d816e047