### PR TITLE
Fix archive type annotations for Python 3.9 compatibility

### DIFF
--- a/pysteam/fs/archive.py
+++ b/pysteam/fs/archive.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import io
 import struct


### PR DESCRIPTION
## Summary
- Import `annotations` from `__future__` in `pysteam.fs.archive` to defer evaluation of `|` union type hints

## Testing
- `python -m py_compile pysteam/fs/archive.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf406d713483309b9d54b4c6f299db