### PR TITLE
Refactor read_file to stream data

### DIFF
--- a/gcfstream.py
+++ b/gcfstream.py
@@ -1,3 +1,11 @@
+"""Streaming access to file data stored inside a :class:`GCFFile`.
+
+The logic is a direct translation of the block traversal performed by
+``GCFStream.cpp`` in HLLib.  It walks the block and fragmentation tables once
+during initialization and then exposes a minimal ``read``/``seek``/``tell``
+interface for consumption by :class:`GCFFile`.
+"""
+
 from __future__ import annotations
 
 import os


### PR DESCRIPTION
## Summary
- document and expose `GCFStream` as a Python port of HLLib's block traversal logic
- add `open_stream` helper returning `GCFStream`
- refactor `read_file` to read data through `GCFStream`

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c10db712f08330a4c5a307ba07b734