### PR TITLE
Handle legacy GCF checksum discrepancies

### DIFF
--- a/pysteam/fs/cachefile.py
+++ b/pysteam/fs/cachefile.py
@@ -5,6 +5,7 @@ import struct
 import os
 import zlib
 import copy
+from types import SimpleNamespace
 
 from typing import Optional, Callable
 
@@ -246,18 +247,9 @@ class CacheFile:
     ) -> None:
         """Convert this cache file to a different GCF format version.
 
-        Parameters
-        ----------
-        target_version:
-            The format version to convert to (e.g. ``1`` or ``6``).
-        out_path:
-            Destination path for the converted archive.
-
-        Notes
-        -----
-        This is an initial implementation that rewrites the header and core
-        tables for ``target_version``.  Data blocks are copied verbatim.  Only
-        GCF archives are supported.
+        The converter rewrites all table headers and recalculates offsets and
+        checksums so that the resulting archive adheres to the requested format.
+        Only GCF archives are supported.
         """
 
         if not self.is_parsed:
@@ -267,38 +259,48 @@ class CacheFile:
         if target_version not in (1, 3, 5, 6):
             raise ValueError("Unsupported GCF version: %d" % target_version)
 
-        header_owner = self.header.owner
-        self.header.owner = None
-        bem_owner = self.block_entry_map.owner if self.block_entry_map else None
-        if self.block_entry_map:
-            self.block_entry_map.owner = None
-        manifest_owner = self.manifest.owner
-        self.manifest.owner = None
+        # Deep copy structures so serialisation does not mutate the source.
+        # Exclude the cache file object (which holds an open stream) from the
+        # copy operation to avoid pickling errors on file-like objects.
+        memo = {id(self): None}
+        try:
+            memo[id(self.stream)] = None  # type: ignore[attr-defined]
+        except Exception:
+            pass
 
-        header = copy.deepcopy(self.header)
-        block_entry_map = copy.deepcopy(self.block_entry_map)
-        manifest = copy.deepcopy(self.manifest)
+        header = copy.deepcopy(self.header, memo)
+        blocks = copy.deepcopy(self.blocks, memo)
+        alloc_table = copy.deepcopy(self.alloc_table, memo)
+        block_entry_map = copy.deepcopy(self.block_entry_map, memo)
+        manifest = copy.deepcopy(self.manifest, memo)
+        data_header = copy.deepcopy(self.data_header, memo)
+        checksum_map = (
+            copy.deepcopy(self.checksum_map, memo) if self.checksum_map else None
+        )
 
-        self.header.owner = header_owner
-        if self.block_entry_map:
-            self.block_entry_map.owner = bem_owner
-        self.manifest.owner = manifest_owner
-
-        header.owner = None
+        # Temporary owner that mirrors the structure expected by the various
+        # serialisation routines.
+        owner = SimpleNamespace(
+            header=header, block_entry_map=block_entry_map, blocks=blocks
+        )
+        manifest.owner = owner
         if block_entry_map:
-            block_entry_map.owner = None
-        manifest.owner = None
+            block_entry_map.owner = owner
+        data_header.owner = owner
+        if checksum_map:
+            checksum_map.owner = owner
 
         header.format_version = target_version
+        blocks.owner = owner
+        alloc_table.owner = owner
 
         original_map_entries = list(manifest.manifest_map_entries)
 
         if target_version < 6:
             if block_entry_map is None:
-                bemap = CacheFileBlockEntryMap(self)
-                bemap.block_count = self.blocks.block_count
-                bemap.entries = list(range(self.blocks.block_count))
-                block_entry_map = bemap
+                block_entry_map = CacheFileBlockEntryMap(owner)
+                block_entry_map.entries = list(range(blocks.block_count))
+                owner.block_entry_map = block_entry_map
             inverse = {blk: idx for idx, blk in enumerate(block_entry_map.entries)}
             manifest.manifest_map_entries = [inverse.get(i, i) for i in original_map_entries]
         else:
@@ -307,34 +309,112 @@ class CacheFile:
                     block_entry_map.entries[i] for i in original_map_entries
                 ]
             block_entry_map = None
+            owner.block_entry_map = None
+
+        # Generate a checksum map when targeting newer formats.
+        if target_version > 1:
+            if checksum_map is None:
+                checksum_map = CacheFileChecksumMap(owner)
+                checksum_map.header_version = 1
+                checksum_map.checksum_size = 4
+                checksum_map.format_code = 1
+                checksum_map.version = 1
+                checksum_map.entries = []
+                checksum_map.checksums = []
+                checksum_map.signature = b"\0" * 128
+                for entry in self.manifest.manifest_entries:
+                    if not (
+                        entry.directory_flags & CacheFileManifestEntry.FLAG_IS_FILE
+                    ):
+                        continue
+                    crc = 0
+                    remaining = entry.item_size
+                    block = entry.first_block
+                    while block is not None and remaining > 0:
+                        for sector in block.sectors:
+                            if remaining <= 0:
+                                break
+                            self.stream.seek(
+                                self.data_header.first_sector_offset
+                                + sector.index * self.header.sector_size
+                            )
+                            chunk = self.stream.read(
+                                min(remaining, self.header.sector_size)
+                            )
+                            crc = zlib.crc32(chunk, crc)
+                            remaining -= len(chunk)
+                            if remaining <= 0:
+                                break
+                        block = block.next_block
+                    checksum_map.entries.append((1, len(checksum_map.checksums)))
+                    checksum_map.checksums.append(crc & 0xFFFFFFFF)
+                checksum_map.file_id_count = len(checksum_map.entries)
+                checksum_map.checksum_count = len(checksum_map.checksums)
+            checksum_map.owner = owner
+        else:
+            checksum_map = None
+            owner.checksum_map = None
+
+        # Recalculate offsets and sizes.
+        header.sector_count = blocks.block_count
+        alloc_table.sector_count = blocks.block_count
+        data_header.sector_count = blocks.block_count
+        header.sector_size = self.header.sector_size
+        data_header.sector_size = self.header.sector_size
+
+        blocks_bytes = blocks.serialize()
+        alloc_bytes = alloc_table.serialize()
+        block_entry_bytes = (
+            block_entry_map.serialize()
+            if target_version < 6 and block_entry_map is not None
+            else b""
+        )
+        manifest_bytes = manifest.serialize()
+        checksum_bytes = (
+            checksum_map.serialize()
+            if target_version > 1 and checksum_map is not None
+            else b""
+        )
+
+        header_size = 44
+        data_header.first_sector_offset = (
+            header_size
+            + len(blocks_bytes)
+            + len(alloc_bytes)
+            + len(block_entry_bytes)
+            + len(manifest_bytes)
+            + len(checksum_bytes)
+        )
+        data_header_bytes = data_header.serialize()
+
+        total_data = data_header.sectors_used * data_header.sector_size
+        header.file_size = (
+            data_header.first_sector_offset + len(data_header_bytes) + total_data
+        )
+
+        header_bytes = header.serialize()
 
         with open(out_path, "wb") as out:
-            out.write(header.serialize())
-            out.write(self.blocks.serialize())
-            out.write(self.alloc_table.serialize())
+            out.write(header_bytes)
+            out.write(blocks_bytes)
+            out.write(alloc_bytes)
+            if block_entry_bytes:
+                out.write(block_entry_bytes)
+            out.write(manifest_bytes)
+            if checksum_bytes:
+                out.write(checksum_bytes)
+            out.write(data_header_bytes)
 
-            if target_version < 6 and block_entry_map is not None:
-                out.write(block_entry_map.serialize())
-
-            out.write(manifest.serialize())
-
-            if self.checksum_map is not None:
-                out.write(self.checksum_map.serialize())
-
-            if self.data_header is not None:
-                out.write(self.data_header.serialize())
-
-                total = self.data_header.sectors_used * self.data_header.sector_size
-                written = 0
-                self.stream.seek(self.data_header.first_sector_offset)
-                while written < total:
-                    chunk = self.stream.read(min(1024 * 1024, total - written))
-                    if not chunk:
-                        break
-                    out.write(chunk)
-                    written += len(chunk)
-                    if progress:
-                        progress(written, total)
+            written = 0
+            self.stream.seek(self.data_header.first_sector_offset)
+            while written < total_data:
+                chunk = self.stream.read(min(1024 * 1024, total_data - written))
+                if not chunk:
+                    break
+                out.write(chunk)
+                written += len(chunk)
+                if progress:
+                    progress(written, total_data)
 
 
     def defragment(
@@ -714,7 +794,9 @@ class CacheFile:
                 chunk = stream.read(to_read)
                 if len(chunk) != to_read:
                     return "size mismatch"
-                chk = (adler32(chunk) & 0xFFFFFFFF) ^ (zlib.crc32(chunk) & 0xFFFFFFFF)
+                chk = (adler32(chunk, 0) & 0xFFFFFFFF) ^ (
+                    zlib.crc32(chunk) & 0xFFFFFFFF
+                )
                 if chk != self.checksum_map.checksums[first + i]:
                     return "checksum mismatch"
                 remaining -= to_read
@@ -960,13 +1042,24 @@ class CacheFileBlockAllocationTableEntry:
             value._next_block_index = self.index
 
     def _get_first_sector(self):
+        """Return the first sector for this block or ``None`` if unused."""
+        alloc_table = self.owner.owner.alloc_table
+        # Block entries that do not reference any data use a sentinel index
+        # equal to the allocation table's terminator value.  Creating a
+        # ``CacheFileSector`` for these entries would attempt to index past the
+        # end of the allocation table and raise ``IndexError``.
+        if self._first_sector_index >= alloc_table.terminator:
+            return None
         return CacheFileSector(self, self._first_sector_index)
 
     def _set_first_sector(self, value):
         self._first_sector_index = value.inde
 
     def _get_is_fragmented(self):
-        return (self.owner.owner.alloc_table[self._first_sector_index] - self._first_sector_index) != -1
+        alloc_table = self.owner.owner.alloc_table
+        if self._first_sector_index >= alloc_table.terminator:
+            return False
+        return (alloc_table[self._first_sector_index] - self._first_sector_index) != -1
 
     next_block = property(_get_next_block, _set_next_block)
     prev_block = property(_get_prev_block, _set_prev_block)
@@ -1007,33 +1100,53 @@ class CacheFileAllocationTable:
     def parse(self, stream):
 
         # Block Header
-        (self.sector_count,
-         self.first_unused_entry,
-         self.is_long_terminator) = struct.unpack("<3L", stream.read(12))
-        # Checksum is stored as the sum of the three header fields rather
-        # than a byte-wise sum of the structure.  The previous implementation
-        # incorrectly summed the raw bytes which caused validation failures on
-        # legitimate v1 GCF files.
+        (
+            self.sector_count,
+            self.first_unused_entry,
+            self.is_long_terminator,
+        ) = struct.unpack("<3L", stream.read(12))
+        # ``uiChecksum`` in ``GCFFragmentationMapHeader`` is a simple 32-bit
+        # sum of the three header fields using unsigned overflow semantics.
+        # Older implementations incorrectly summed the raw bytes which caused
+        # validation failures on legitimate v1 GCF files.
         (self.checksum,) = struct.unpack("<L", stream.read(4))
 
         self.terminator = 0xFFFFFFFF if self.is_long_terminator else 0xFFFF
         self.entries = unpack_dword_list(stream, self.sector_count)
 
     def serialize(self):
-        data = struct.pack("<3L", self.sector_count, self.first_unused_entry, self.is_long_terminator)
+        data = struct.pack(
+            "<3L",
+            self.sector_count,
+            self.first_unused_entry,
+            self.is_long_terminator,
+        )
         # Cache the checksum so subsequent calls to ``serialize`` or
         # ``calculate_checksum`` are in agreement with the on-disk format.
-        self.checksum = self.sector_count + self.first_unused_entry + self.is_long_terminator
+        self.checksum = self.calculate_checksum()
         return data + struct.pack("<L", self.checksum) + pack_dword_list(self.entries)
 
     def calculate_checksum(self):
-        return self.sector_count + self.first_unused_entry + self.is_long_terminator
+        return (
+            self.sector_count
+            + self.first_unused_entry
+            + self.is_long_terminator
+        ) & 0xFFFFFFFF
 
     def validate(self):
         if self.owner.header.sector_count != self.sector_count:
-            raise ValueError("Invalid Cache Allocation Table [SectorCounts do not match]")
-        if self.checksum != self.calculate_checksum():
-            raise ValueError("Invalid Cache Allocation Table [Checksums do not match]")
+            raise ValueError(
+                "Invalid Cache Allocation Table [SectorCounts do not match]"
+            )
+        # Very old GCF files often contain an incorrect checksum here.  The
+        # reference C++ implementation does not enforce this for legacy
+        # archives so we only validate for newer formats where the field is
+        # known to be reliable.
+        if self.owner.header.format_version > 1:
+            if self.checksum != self.calculate_checksum():
+                raise ValueError(
+                    "Invalid Cache Allocation Table [Checksums do not match]"
+                )
 
 class CacheFileBlockEntryMap:
 
@@ -1438,13 +1551,27 @@ class CacheFileSectorHeader:
             raise ValueError(
                 "Invalid Cache File Sector Header [SectorSize mismatch]"
             )
-        if self.checksum != self.calculate_checksum():
+        # Some early (v1) GCF files are known to store an invalid checksum in
+        # the data header.  HLLib ignores this discrepancy, so we only enforce
+        # checksum validation for newer format revisions.
+        if self.format_version > 1 and self.checksum != self.calculate_checksum():
             raise ValueError(
                 "Invalid Cache File Sector Header [Checksum mismatch]"
             )
 
     def calculate_checksum(self):
-        return self.sector_count + self.sector_size + self.first_sector_offset + self.sectors_used
+        # The checksum stored in the data header is a 32-bit unsigned sum of
+        # the following fields.  Clamp intermediate results to 32 bits to match
+        # the behavior of the original C++ implementation.
+        checksum = 0
+        for value in (
+            self.sector_count,
+            self.sector_size,
+            self.first_sector_offset,
+            self.sectors_used,
+        ):
+            checksum = (checksum + value) & 0xFFFFFFFF
+        return checksum
 
 class CacheFileSector:
 


### PR DESCRIPTION
## Summary
- Relax CacheFileSectorHeader validation for very old GCF files
- Calculate sector and allocation table checksums using 32-bit overflow semantics
- Skip block entries that reference no data to avoid allocation table overrun
- Ignore allocation table checksum mismatches for legacy format version 1
- Rebuild headers and tables when converting GCF archives, generating missing checksum maps and recalculating offsets for target versions
- Use Adler-32 with a zero seed during file validation so known good archives don't report false checksum mismatches
- Avoid deep-copying open file handles during version conversion to prevent pickling errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2008c824083309a97261bc77a3bca