### PR TITLE
Fix manifest checksum calculation

### DIFF
--- a/tests/test_gcf_manifest_checksum.py
+++ b/tests/test_gcf_manifest_checksum.py
@@ -1,0 +1,19 @@
+import zlib
+
+from pysteam.fs.cachefile import CacheFile
+
+
+def test_manifest_checksum(tmp_path):
+    data = {"a.txt": b"hello"}
+    cf = CacheFile.build(data, app_id=1, app_version=1)
+    out = tmp_path / "test.gcf"
+    cf.convert_version(6, out)
+    rebuilt = CacheFile.parse(out)
+    manifest = rebuilt.manifest.serialize()
+    body_end = rebuilt.manifest.binary_size
+    calc = (
+        zlib.adler32(manifest[:0x30] + b"\x00" * 8 + manifest[0x38:body_end], 0)
+        & 0xFFFFFFFF
+    )
+    assert calc == rebuilt.manifest.checksum
+

--- a/tests/test_gcf_manifest_hashtable.py
+++ b/tests/test_gcf_manifest_hashtable.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+from io import BytesIO
+from pysteam.fs.cachefile import CacheFile
+
+
+def test_manifest_hashtable(tmp_path):
+    data = {"a.txt": b"hello"}
+    cf = CacheFile.build(data, app_id=1, app_version=1)
+    out = tmp_path / "test.gcf"
+    cf.convert_version(6, out)
+    rebuilt = CacheFile.parse(out)
+    sys.path.append(str(Path(__file__).resolve().parents[1] / "py_gcf_validator"))
+    from manifest import Manifest
+
+    Manifest(BytesIO(rebuilt.manifest.serialize()), adjust_size=True)


### PR DESCRIPTION
## Summary
- implement Jenkins hash and construct manifest hash table when building new GCFs
- ensure directory entries mark file ID as unused and record child counts
- add regression test verifying new manifests parse with external validator

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2302b1d6083309151e36da57fc841