### PR TITLE
Fix parsing of legacy GCF block entries

### DIFF
--- a/tests/test_gcf_block_entry_v1_layout.py
+++ b/tests/test_gcf_block_entry_v1_layout.py
@@ -1,0 +1,29 @@
+import struct
+from types import SimpleNamespace
+from io import BytesIO
+
+from pysteam.fs.cachefile import CacheFileBlockAllocationTableEntry
+
+
+def test_parse_and_serialize_v1_block_entry():
+    # Craft a v1 block entry with a 32-bit flags field that includes
+    # high bits to ensure proper splitting across the v6 layout.
+    flags = 0x80004004
+    raw = struct.pack("<7L", flags, 1, 2, 3, 4, 5, 6)
+
+    cf = SimpleNamespace(header=SimpleNamespace(format_version=1))
+    bat = SimpleNamespace(owner=cf)
+    entry = CacheFileBlockAllocationTableEntry(bat)
+    entry.parse(BytesIO(raw))
+
+    assert entry.flags == flags
+    assert entry.entry_flags == flags & 0xFFFF
+    assert entry.dummy0 == (flags >> 16) & 0xFFFF
+
+    # Serialising with v1 layout should reproduce the original bytes.
+    assert entry.serialize() == raw
+
+    # Switching to a v6 header should emit the split flag structure.
+    cf.header.format_version = 6
+    expected_v6 = struct.pack("<2H6L", flags & 0xFFFF, (flags >> 16) & 0xFFFF, 1, 2, 3, 4, 5, 6)
+    assert entry.serialize() == expected_v6

--- a/tests/test_gcf_v1_to_v6_conversion.py
+++ b/tests/test_gcf_v1_to_v6_conversion.py
@@ -28,5 +28,12 @@ def test_convert_v1_to_v6_has_required_tables(tmp_path):
         rebuilt.checksum_map.checksum_size
         == len(rebuilt.checksum_map.serialize()) - 8
     )
+    assert rebuilt.header.dummy1 == 0
+    assert rebuilt.blocks.dummy1 == 0
+    assert rebuilt.blocks.dummy2 == 0
+    assert rebuilt.blocks.dummy3 == 0
+    assert rebuilt.blocks.dummy4 == 0
+    assert rebuilt.blocks.checksum == rebuilt.blocks.calculate_checksum()
+    assert rebuilt.alloc_table.checksum == rebuilt.alloc_table.calculate_checksum()
 
     # Reference validator does not support the reduced v6 layout.


### PR DESCRIPTION
## Summary
- rebuild block allocation table header and checksum when upgrading to v6
- zero legacy dummy fields in v6 conversions
- extend v1→v6 roundtrip test to assert header checksums and dummies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4dae5fb148330ade5ea67581e89c7