### PR TITLE
Mask block entry values before packing

### DIFF
--- a/pysteam/fs/cachefile.py
+++ b/pysteam/fs/cachefile.py
@@ -191,7 +191,8 @@ def pack_dword_list(values):
     values = list(values)
     if not values:
         return b""
-    return struct.pack(f"<{len(values)}L", *values)
+    masked = [v & 0xFFFFFFFF for v in values]
+    return struct.pack(f"<{len(masked)}L", *masked)
 
 def raise_parse_error(func):
     def internal(self, *args, **kwargs):
@@ -1706,27 +1707,27 @@ class CacheFileBlockAllocationTableEntry:
     def serialize(self):
         fmt = self.owner.owner.header.format_version
         if fmt <= 1:
-            flags = (self.dummy0 << 16) | self.entry_flags
+            flags = ((self.dummy0 & 0xFFFF) << 16) | (self.entry_flags & 0xFFFF)
             return struct.pack(
                 "<7L",
                 flags,
-                self.file_data_offset,
-                self.file_data_size,
-                self._first_sector_index,
-                self._next_block_index,
-                self._prev_block_index,
-                self.manifest_index,
+                self.file_data_offset & 0xFFFFFFFF,
+                self.file_data_size & 0xFFFFFFFF,
+                self._first_sector_index & 0xFFFFFFFF,
+                self._next_block_index & 0xFFFFFFFF,
+                self._prev_block_index & 0xFFFFFFFF,
+                self.manifest_index & 0xFFFFFFFF,
             )
         return struct.pack(
             "<2H6L",
-            self.entry_flags,
-            self.dummy0,
-            self.file_data_offset,
-            self.file_data_size,
-            self._first_sector_index,
-            self._next_block_index,
-            self._prev_block_index,
-            self.manifest_index,
+            self.entry_flags & 0xFFFF,
+            self.dummy0 & 0xFFFF,
+            self.file_data_offset & 0xFFFFFFFF,
+            self.file_data_size & 0xFFFFFFFF,
+            self._first_sector_index & 0xFFFFFFFF,
+            self._next_block_index & 0xFFFFFFFF,
+            self._prev_block_index & 0xFFFFFFFF,
+            self.manifest_index & 0xFFFFFFFF,
         )
 
 class CacheFileAllocationTable:

--- a/tests/test_pack_masking.py
+++ b/tests/test_pack_masking.py
@@ -1,0 +1,40 @@
+import struct
+from types import SimpleNamespace
+
+from pysteam.fs.cachefile import (
+    CacheFileBlockAllocationTableEntry,
+    pack_dword_list,
+)
+
+
+def test_pack_dword_list_masks_out_of_range_values():
+    data = pack_dword_list([0x1_0000_0000, -1])
+    assert data == struct.pack("<2L", 0, 0xFFFFFFFF)
+
+
+def test_block_entry_serialize_masks_large_fields():
+    cf = SimpleNamespace(header=SimpleNamespace(format_version=6))
+    bat = SimpleNamespace(owner=cf)
+    entry = CacheFileBlockAllocationTableEntry(bat)
+    entry.entry_flags = 0x123456
+    entry.dummy0 = 0xABCDEF
+    entry.file_data_offset = 0x1_0000_0001
+    entry.file_data_size = 0x1_0000_0002
+    entry._first_sector_index = 0x1_0000_0003
+    entry._next_block_index = 0x1_0000_0004
+    entry._prev_block_index = 0x1_0000_0005
+    entry.manifest_index = 0x1_0000_0006
+
+    data = entry.serialize()
+    expected = struct.pack(
+        "<2H6L",
+        entry.entry_flags & 0xFFFF,
+        entry.dummy0 & 0xFFFF,
+        entry.file_data_offset & 0xFFFFFFFF,
+        entry.file_data_size & 0xFFFFFFFF,
+        entry._first_sector_index & 0xFFFFFFFF,
+        entry._next_block_index & 0xFFFFFFFF,
+        entry._prev_block_index & 0xFFFFFFFF,
+        entry.manifest_index & 0xFFFFFFFF,
+    )
+    assert data == expected


### PR DESCRIPTION
## Summary
- prevent struct errors by masking DWORD lists and block entry fields to 32-bit
- add regression tests ensuring oversized values serialize correctly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c4de127aa083309ed0ef77a356b28f