### PR TITLE
Fix checksum calculation for GCF v6 and add toggleable minimum footprint option

### DIFF
--- a/py_gcf_validator/v6_validator.py
+++ b/py_gcf_validator/v6_validator.py
@@ -243,10 +243,10 @@ def validate_v6(cache: CacheFile) -> List[str]:
             actual = []
             for offset in range(0, len(data), CACHE_CHECKSUM_LENGTH):
                 chunk = data[offset:offset + CACHE_CHECKSUM_LENGTH]
-                chk = (zlib.crc32(chunk) ^ zlib.adler32(chunk)) & 0xFFFFFFFF
+                chk = (zlib.crc32(chunk) ^ zlib.adler32(chunk, 0)) & 0xFFFFFFFF
                 actual.append(chk)
             if not actual:
-                chk = (zlib.crc32(b"") ^ zlib.adler32(b"")) & 0xFFFFFFFF
+                chk = (zlib.crc32(b"") ^ zlib.adler32(b"", 0)) & 0xFFFFFFFF
                 actual.append(chk)
             if expected != actual:
                 errors.append(f"Checksum mismatch for {f.path()}")

--- a/pysteam/fs/cachefile.py
+++ b/pysteam/fs/cachefile.py
@@ -446,11 +446,11 @@ class CacheFile:
                 chunk_count = 0
                 for offset in range(0, len(data), CACHE_CHECKSUM_LENGTH):
                     chunk = data[offset : offset + CACHE_CHECKSUM_LENGTH]
-                    chk = (zlib.crc32(chunk) ^ adler32(chunk)) & 0xFFFFFFFF
+                    chk = (zlib.crc32(chunk) ^ adler32(chunk, 0)) & 0xFFFFFFFF
                     checksums.append(chk)
                     chunk_count += 1
                 if chunk_count == 0:
-                    chk = (zlib.crc32(b"") ^ adler32(b"")) & 0xFFFFFFFF
+                    chk = (zlib.crc32(b"") ^ adler32(b"", 0)) & 0xFFFFFFFF
                     checksums.append(chk)
                     chunk_count = 1
                 checksum_entries.append((chunk_count, start))
@@ -727,13 +727,13 @@ class CacheFile:
                             while len(buffer) >= CACHE_CHECKSUM_LENGTH:
                                 part = buffer[:CACHE_CHECKSUM_LENGTH]
                                 del buffer[:CACHE_CHECKSUM_LENGTH]
-                                chk = (zlib.crc32(part) ^ adler32(part)) & 0xFFFFFFFF
+                                chk = (zlib.crc32(part) ^ adler32(part, 0)) & 0xFFFFFFFF
                                 checksum_map.checksums.append(chk)
                                 chunk_count += 1
                             if remaining <= 0:
                                 break
                         block = block.next_block
-                    chk = (zlib.crc32(buffer) ^ adler32(buffer)) & 0xFFFFFFFF
+                    chk = (zlib.crc32(buffer) ^ adler32(buffer, 0)) & 0xFFFFFFFF
                     checksum_map.checksums.append(chk)
                     chunk_count += 1
                     checksum_map.entries.append((chunk_count, start))

--- a/tests/test_gcf_checksum_validation.py
+++ b/tests/test_gcf_checksum_validation.py
@@ -1,0 +1,11 @@
+from pysteam.fs.cachefile import CacheFile
+
+
+def test_v6_checksum_validation(tmp_path):
+    data = {"a.txt": b"hello", "b.txt": b"world"}
+    cf = CacheFile.build(data, app_id=1, app_version=1)
+    out = tmp_path / "test.gcf"
+    cf.convert_version(6, out)
+    cf.close()
+    rebuilt = CacheFile.parse(out)
+    assert rebuilt.validate() == []

--- a/tests/test_minimum_footprint_action.py
+++ b/tests/test_minimum_footprint_action.py
@@ -1,0 +1,48 @@
+import os
+os.environ.setdefault('QT_QPA_PLATFORM', 'offscreen')
+
+from PyQt5.QtWidgets import QApplication
+
+from gcfscape_gui import GCFScapeWindow
+from pysteam.fs.cachefile import CacheFile, CacheFileManifestEntry
+
+
+def test_minimum_footprint_action_toggle(tmp_path):
+    app = QApplication.instance() or QApplication([])
+
+    files = {
+        "folder/a.txt": b"a",
+        "folder/b.txt": b"b",
+        "c.txt": b"c",
+    }
+    cf = CacheFile.build(files, app_id=1, app_version=1)
+
+    win = GCFScapeWindow()
+    win.cachefile = cf
+
+    folder = cf.root["folder"]
+    file_c = cf.root["c.txt"]
+    win._selected_entries = lambda: [folder, file_c]
+
+    win._toggle_minimum_footprint(True)
+
+    indices = set(cf.manifest.minimum_footprint_entries)
+    assert cf.root["folder"]["a.txt"].index in indices
+    assert cf.root["folder"]["b.txt"].index in indices
+    assert cf.root["c.txt"].index in indices
+
+    flag = CacheFileManifestEntry.FLAG_IS_PURGE_FILE
+    assert cf.root["folder"]["a.txt"].flags & flag
+    assert cf.root["c.txt"].flags & flag
+
+    win._update_edit_actions()
+    assert win.minimum_footprint_action.isChecked()
+
+    win._toggle_minimum_footprint(False)
+
+    assert cf.manifest.minimum_footprint_entries == []
+    assert not cf.root["folder"]["a.txt"].flags & flag
+    assert not cf.root["c.txt"].flags & flag
+
+    win._update_edit_actions()
+    assert not win.minimum_footprint_action.isChecked()


### PR DESCRIPTION
## Summary
- compute checksum blocks using adler32 with a zero seed in the GCF builder and converter
- update v6 validator to match adler32 usage
- add regression test to ensure generated v6 GCF files validate cleanly
- add an Edit menu action to mark selected files or folders as minimum footprint
- make the minimum footprint option toggleable with a checkmark and support removing entries on repeat click
- test that the new action correctly updates manifest, flags, and menu state

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4ea74edc88330b0aefe2185fe308a